### PR TITLE
Remove runtime chdir and operator requires

### DIFF
--- a/lib/conceptql/operators/after.rb
+++ b/lib/conceptql/operators/after.rb
@@ -3,6 +3,8 @@ require_relative 'temporal_operator'
 module ConceptQL
   module Operators
     class After < TemporalOperator
+      register __FILE__
+
       desc <<-EOF
 Compares all results on a person-by-person basis between the left hand results (LHR) and the right hand resuls (RHR).
 For any result in the LHR whose start_date occurs after the earliest end_date of the RHR, that result is passed through.

--- a/lib/conceptql/operators/any_overlap.rb
+++ b/lib/conceptql/operators/any_overlap.rb
@@ -3,6 +3,8 @@ require_relative 'temporal_operator'
 module ConceptQL
   module Operators
     class AnyOverlap < TemporalOperator
+      register __FILE__
+
       desc 'If a result from the LHR overlaps in any way a result from the RHR it is passed along.'
       def where_clause
         l_partly_in_r = Sequel.expr { r__start_date <= l__start_date }.&(Sequel.expr { l__start_date <= r__end_date })

--- a/lib/conceptql/operators/before.rb
+++ b/lib/conceptql/operators/before.rb
@@ -3,6 +3,8 @@ require_relative 'temporal_operator'
 module ConceptQL
   module Operators
     class Before < TemporalOperator
+      register __FILE__
+
       desc <<-EOF
 Compares all results on a person-by-person basis between the left hand results (LHR) and the right hand resuls (RHR).
 For any result in the LHR whose end_date occurs before the most recent start_date of the RHR, that result is passed through.

--- a/lib/conceptql/operators/binary_operator_operator.rb
+++ b/lib/conceptql/operators/binary_operator_operator.rb
@@ -5,6 +5,8 @@ module ConceptQL
   module Operators
     # Base class for all operators that take two streams, a left-hand and a right-hand
     class BinaryOperatorOperator < Operator
+      register __FILE__
+
       option :left, type: :upstream
       option :right, type: :upstream
 

--- a/lib/conceptql/operators/casting_operator.rb
+++ b/lib/conceptql/operators/casting_operator.rb
@@ -23,6 +23,8 @@ module ConceptQL
     # Also, if a casting operator is passed no streams, it will return all the
     # rows in its table as results.
     class CastingOperator < Operator
+      register __FILE__
+
       category 'Casting'
       def types
         [type]

--- a/lib/conceptql/operators/complement.rb
+++ b/lib/conceptql/operators/complement.rb
@@ -3,6 +3,8 @@ require_relative 'pass_thru'
 module ConceptQL
   module Operators
     class Complement < PassThru
+      register __FILE__
+
       desc 'Splits up the incoming result set by type and passes through all results for each type that are NOT in the current set.'
       allows_one_upstream
       category 'Set Logic'

--- a/lib/conceptql/operators/concept.rb
+++ b/lib/conceptql/operators/concept.rb
@@ -4,6 +4,8 @@ require_relative '../query'
 module ConceptQL
   module Operators
     class Concept < Operator
+      register __FILE__
+
       desc 'Given the UUID of another ConceptQL statement, returns the results of that statement.'
       attr :cql_query
       def query(db)

--- a/lib/conceptql/operators/condition_type.rb
+++ b/lib/conceptql/operators/condition_type.rb
@@ -10,6 +10,8 @@ module ConceptQL
     #
     # Multiple types can be specified at once
     class ConditionType < Operator
+      register __FILE__
+
       desc 'Searches for conditions that match the given set of Condition Types'
       argument :condition_types, type: :codelist, vocab: 'Condition Type'
       category %(Occurrence Type)

--- a/lib/conceptql/operators/contains.rb
+++ b/lib/conceptql/operators/contains.rb
@@ -3,6 +3,8 @@ require_relative 'temporal_operator'
 module ConceptQL
   module Operators
     class Contains < TemporalOperator
+      register __FILE__
+
       desc <<-EOF
 Any result in the LHR whose start_date is on or before and whose end_date is on or after a result from the RHR.
 L--X-L

--- a/lib/conceptql/operators/count.rb
+++ b/lib/conceptql/operators/count.rb
@@ -3,6 +3,8 @@ require_relative 'pass_thru'
 module ConceptQL
   module Operators
     class Count < PassThru
+      register __FILE__
+
       desc 'Counts the number of results the exactly match across all columns.'
       allows_one_upstream
 

--- a/lib/conceptql/operators/cpt.rb
+++ b/lib/conceptql/operators/cpt.rb
@@ -3,6 +3,8 @@ require_relative 'standard_vocabulary_operator'
 module ConceptQL
   module Operators
     class Cpt < StandardVocabularyOperator
+      register __FILE__
+
       preferred_name 'CPT'
       desc 'Searches the procedure_occurrence table for all procedures with matching CPT codes'
       argument :cpts, type: :codelist, vocab: 'CPT4'

--- a/lib/conceptql/operators/date_range.rb
+++ b/lib/conceptql/operators/date_range.rb
@@ -8,6 +8,8 @@ module ConceptQL
     # 'START' represents the first date of data in the data source,
     # 'END' represents the last date of data in the data source,
     class DateRange < Operator
+      register __FILE__
+
       desc 'Used to represent a date literal.'
       option :start, type: :string
       option :end, type: :string

--- a/lib/conceptql/operators/death.rb
+++ b/lib/conceptql/operators/death.rb
@@ -3,6 +3,8 @@ require_relative 'casting_operator'
 module ConceptQL
   module Operators
     class Death < CastingOperator
+      register __FILE__
+
       desc 'Generates all death records, or, if fed a stream, fetches all death records for the people represented in the incoming result set.'
       types :death
       allows_one_upstream

--- a/lib/conceptql/operators/drug_type_concept.rb
+++ b/lib/conceptql/operators/drug_type_concept.rb
@@ -3,6 +3,8 @@ require_relative 'operator'
 module ConceptQL
   module Operators
     class DrugTypeConcept < Operator
+      register __FILE__
+
       desc 'Given a set of concept IDs in RxNorm, returns that set of drug exposures'
       argument :concept_ids, type: :codelist, vocab: 'RxNorm'
 

--- a/lib/conceptql/operators/during.rb
+++ b/lib/conceptql/operators/during.rb
@@ -3,6 +3,8 @@ require_relative 'temporal_operator'
 module ConceptQL
   module Operators
     class During < TemporalOperator
+      register __FILE__
+
       desc <<-EOF
 Compares all results on a person-by-person basis between the left hand results (LHR) and the right hand resuls (RHR).
 For any result in the LHR whose start_date and end_date occur within the start_date and end_date of a RHR row, that result is passed through.

--- a/lib/conceptql/operators/equal.rb
+++ b/lib/conceptql/operators/equal.rb
@@ -3,6 +3,8 @@ require_relative 'temporal_operator'
 module ConceptQL
   module Operators
     class Equal < TemporalOperator
+      register __FILE__
+
       desc 'If a LHR result has the same value_as_number as a RHR result, it is passed through'
 
       def where_clause

--- a/lib/conceptql/operators/except.rb
+++ b/lib/conceptql/operators/except.rb
@@ -3,6 +3,8 @@ require_relative 'binary_operator_operator'
 module ConceptQL
   module Operators
     class Except < BinaryOperatorOperator
+      register __FILE__
+
       desc 'If a LHR result appears in the RHR result, it is removed from the output result set.'
       category 'Set Logic'
 

--- a/lib/conceptql/operators/filter.rb
+++ b/lib/conceptql/operators/filter.rb
@@ -3,6 +3,8 @@ require_relative 'binary_operator_operator'
 module ConceptQL
   module Operators
     class Filter < BinaryOperatorOperator
+      register __FILE__
+
       desc 'Only pass through results from the LHR that have a corresponding RHR with the same person, criterion_id, and criterion_type'
 
       def query(db)

--- a/lib/conceptql/operators/first.rb
+++ b/lib/conceptql/operators/first.rb
@@ -15,6 +15,8 @@ module ConceptQL
     # If we ask for the first occurrence of something and a person has no
     # occurrences, this operator returns nothing for that person
     class First < Occurrence
+      register __FILE__
+
       desc 'Only passes through the row with the earliest start_date per person.  If more than one row qualifies, result is arbitrarily chosen.'
 
       def occurrence

--- a/lib/conceptql/operators/from.rb
+++ b/lib/conceptql/operators/from.rb
@@ -3,6 +3,8 @@ require_relative 'pass_thru'
 module ConceptQL
   module Operators
     class From < Operator
+      register __FILE__
+
       def query(db)
         db.from(values.first)
       end

--- a/lib/conceptql/operators/from_seer_visits.rb
+++ b/lib/conceptql/operators/from_seer_visits.rb
@@ -3,6 +3,8 @@ require_relative 'operator'
 module ConceptQL
   module Operators
     class FromSeerVisits < Operator
+      register __FILE__
+
       def type
         :observation
       end

--- a/lib/conceptql/operators/gender.rb
+++ b/lib/conceptql/operators/gender.rb
@@ -3,6 +3,8 @@ require_relative 'operator'
 module ConceptQL
   module Operators
     class Gender < Operator
+      register __FILE__
+
       desc 'Returns all person records that match the selected gender.'
       argument :gender, type: :string, options: ['Male', 'Female']
       types :person

--- a/lib/conceptql/operators/hcpcs.rb
+++ b/lib/conceptql/operators/hcpcs.rb
@@ -3,6 +3,8 @@ require_relative 'standard_vocabulary_operator'
 module ConceptQL
   module Operators
     class Hcpcs < StandardVocabularyOperator
+      register __FILE__
+
       preferred_name 'HCPCS'
       desc 'Searches the procedure_occurrence table for all procedures with matching HCPCS codes'
       argument :hcpcs, type: :codelist, vocab: 'HCPCS'

--- a/lib/conceptql/operators/icd10.rb
+++ b/lib/conceptql/operators/icd10.rb
@@ -3,6 +3,8 @@ require_relative 'source_vocabulary_operator'
 module ConceptQL
   module Operators
     class Icd10 < SourceVocabularyOperator
+      register __FILE__
+
       preferred_name 'ICD-10 CM'
       desc 'Searches the condition_occurrence table for the given set of ICD-10 codes.'
       argument :icd10s, type: :codelist, vocab: 'ICD10CM'

--- a/lib/conceptql/operators/icd9.rb
+++ b/lib/conceptql/operators/icd9.rb
@@ -3,6 +3,8 @@ require_relative 'source_vocabulary_operator'
 module ConceptQL
   module Operators
     class Icd9 < SourceVocabularyOperator
+      register __FILE__
+
       preferred_name 'ICD-9 CM'
       desc 'Searches the condition_occurrence table for the given set of ICD-9 codes.'
       argument :icd9s, type: :codelist, vocab: 'ICD9CM'

--- a/lib/conceptql/operators/icd9_procedure.rb
+++ b/lib/conceptql/operators/icd9_procedure.rb
@@ -3,6 +3,8 @@ require_relative 'standard_vocabulary_operator'
 module ConceptQL
   module Operators
     class Icd9Procedure < StandardVocabularyOperator
+      register __FILE__
+
       preferred_name 'ICD-9 Proc'
       desc 'Searches the procedure_occurrence table for the given set of ICD-9 codes.'
       argument :icd9s, type: :codelist, vocab: 'ICD9Proc'

--- a/lib/conceptql/operators/intersect.rb
+++ b/lib/conceptql/operators/intersect.rb
@@ -3,6 +3,8 @@ require_relative 'pass_thru'
 module ConceptQL
   module Operators
     class Intersect < PassThru
+      register __FILE__
+
       desc 'Passes thru any result row that appears in all incoming result sets.'
       allows_many_upstreams
       category 'Set Logic'

--- a/lib/conceptql/operators/last.rb
+++ b/lib/conceptql/operators/last.rb
@@ -15,6 +15,8 @@ module ConceptQL
     # If we ask for the last occurrence of something and a person has no
     # occurrences, this operator returns nothing for that person
     class Last < Occurrence
+      register __FILE__
+
       desc 'Only passes through the row with the most recent start_date per person.  If more than one row qualifies, result is arbitrarily chosen.'
 
       def occurrence

--- a/lib/conceptql/operators/loinc.rb
+++ b/lib/conceptql/operators/loinc.rb
@@ -3,6 +3,8 @@ require_relative 'standard_vocabulary_operator'
 module ConceptQL
   module Operators
     class Loinc < StandardVocabularyOperator
+      register __FILE__
+
       preferred_name 'LOINC'
       desc 'Searches the observation table for all observations with matching LOINC codes'
       argument :loincs, type: :codelist, vocab: 'LOINC'

--- a/lib/conceptql/operators/medcode.rb
+++ b/lib/conceptql/operators/medcode.rb
@@ -3,6 +3,8 @@ require_relative 'source_vocabulary_operator'
 module ConceptQL
   module Operators
     class Medcode < SourceVocabularyOperator
+      register __FILE__
+
       desc 'Searches the condition_occurrence table for all conditions with matching Medcodes'
       argument :medcodes, type: :codelist, vocab_id: '203'
       predominant_types :condition_occurrence

--- a/lib/conceptql/operators/medcode_procedure.rb
+++ b/lib/conceptql/operators/medcode_procedure.rb
@@ -3,6 +3,8 @@ require_relative 'source_vocabulary_operator'
 module ConceptQL
   module Operators
     class MedcodeProcedure < SourceVocabularyOperator
+      register __FILE__
+
       desc 'Searches the procedure_occurrence table for all procedures with matching Medcodes'
       argument :medcodes, type: :codelist, vocab: '204'
       predominant_types :procedure_occurrence

--- a/lib/conceptql/operators/ndc.rb
+++ b/lib/conceptql/operators/ndc.rb
@@ -3,6 +3,8 @@ require_relative 'source_vocabulary_operator'
 module ConceptQL
   module Operators
     class Ndc < SourceVocabularyOperator
+      register __FILE__
+
       preferred_name 'NDC'
       desc 'Searches the drug_exposure table for all procedures with matching NDC codes'
       argument :ndcs, type: :codelist, vocab: 'NDC'

--- a/lib/conceptql/operators/numeric.rb
+++ b/lib/conceptql/operators/numeric.rb
@@ -12,6 +12,8 @@ module ConceptQL
     # - Either a number value or a symbol representing a column name
     # - An optional stream
     class Numeric < PassThru
+      register __FILE__
+
       desc <<-EOF
 Represents a operator that will either:
 - create a value_as_number value for every person in the database

--- a/lib/conceptql/operators/observation_by_enttype.rb
+++ b/lib/conceptql/operators/observation_by_enttype.rb
@@ -3,6 +3,8 @@ require_relative 'source_vocabulary_operator'
 module ConceptQL
   module Operators
     class ObservationByEnttype < SourceVocabularyOperator
+      register __FILE__
+
       desc 'Searches the observation table for all observations with matching Enttype'
       argument :enttypes, type: :codelist, vocab_id: [206, 207]
       predominant_types :observation

--- a/lib/conceptql/operators/observation_period.rb
+++ b/lib/conceptql/operators/observation_period.rb
@@ -3,6 +3,8 @@ require_relative 'casting_operator'
 module ConceptQL
   module Operators
     class ObservationPeriod < CastingOperator
+      register __FILE__
+
       desc 'Generates all observation_period records, or, if fed a stream, fetches all observation_period records for the people represented in the incoming result set.'
       types :observation_period
       allows_one_upstream

--- a/lib/conceptql/operators/occurrence.rb
+++ b/lib/conceptql/operators/occurrence.rb
@@ -22,6 +22,8 @@ module ConceptQL
     # If we ask for the second occurrence of something and a person has only one
     # occurrence, this operator returns nothing for that person
     class Occurrence < Operator
+      register __FILE__
+
       preferred_name 'Nth Occurrence'
       desc <<-EOF
 Groups all results by person, then orders by start_date, then finds the nth occurrence.

--- a/lib/conceptql/operators/one_in_two_out.rb
+++ b/lib/conceptql/operators/one_in_two_out.rb
@@ -4,6 +4,8 @@ require_relative 'visit_occurrence'
 module ConceptQL
   module Operators
     class OneInTwoOut < Operator
+      register __FILE__
+
       desc <<-EOF
 Represents a common pattern in research algorithms: searching for a condition
 that appears either two times in an outpatient setting with a 30-day gap or once

--- a/lib/conceptql/operators/operator.rb
+++ b/lib/conceptql/operators/operator.rb
@@ -6,6 +6,12 @@ require 'forwardable'
 
 module ConceptQL
   module Operators
+    OPERATORS = {}
+
+    def self.operators
+      OPERATORS
+    end
+
     class Operator
       extend Forwardable
       extend Metadatable
@@ -25,6 +31,10 @@ module ConceptQL
       attr :values, :options, :arguments, :upstreams
 
       option :label, type: :string
+
+      def self.register(file)
+        OPERATORS[File.basename(file).sub(/\.rb\z/, '')] = self
+      end
 
       def initialize(*args)
         set_values(*args)
@@ -234,3 +244,9 @@ module ConceptQL
     end
   end
 end
+
+# Require all operator subclasses eagerly
+Dir.new(File.dirname(__FILE__)).
+  entries.
+  each{|filename| require_relative filename if filename =~ /\.rb\z/ && filename != File.basename(__FILE__)}
+ConceptQL::Operators.operators.freeze

--- a/lib/conceptql/operators/overlapped_by.rb
+++ b/lib/conceptql/operators/overlapped_by.rb
@@ -3,6 +3,8 @@ require_relative 'temporal_operator'
 module ConceptQL
   module Operators
     class OverlappedBy < TemporalOperator
+      register __FILE__
+
       desc <<-EOF
 Compares all results on a person-by-person basis between the left hand results (LHR) and the right hand resuls (RHR).
 For any result in the LHR whose start_date occurs between the start_date and end_date of a result from the RHR, that result is passed through.

--- a/lib/conceptql/operators/overlaps.rb
+++ b/lib/conceptql/operators/overlaps.rb
@@ -3,6 +3,8 @@ require_relative 'temporal_operator'
 module ConceptQL
   module Operators
     class Overlaps < TemporalOperator
+      register __FILE__
+
       desc <<-EOF
 Compares all results on a person-by-person basis between the left hand results (LHR) and the right hand resuls (RHR).
 For any result in the LHR whose end_date occurs between the start_date and end_date of a result from the RHR, that result is passed through.

--- a/lib/conceptql/operators/pass_thru.rb
+++ b/lib/conceptql/operators/pass_thru.rb
@@ -3,6 +3,8 @@ require_relative 'operator'
 module ConceptQL
   module Operators
     class PassThru < Operator
+      register __FILE__
+
       def types
         upstreams.map(&:types).flatten.uniq
       end

--- a/lib/conceptql/operators/person.rb
+++ b/lib/conceptql/operators/person.rb
@@ -3,6 +3,8 @@ require_relative 'casting_operator'
 module ConceptQL
   module Operators
     class Person < CastingOperator
+      register __FILE__
+
       desc 'Returns all people in the database, or if given a upstream, converts all results to the set of patients contained in those results.'
       allows_one_upstream
       types :person

--- a/lib/conceptql/operators/person_filter.rb
+++ b/lib/conceptql/operators/person_filter.rb
@@ -3,6 +3,8 @@ require_relative 'binary_operator_operator'
 module ConceptQL
   module Operators
     class PersonFilter < BinaryOperatorOperator
+      register __FILE__
+
       desc 'Only passes through a result from the LHR if the person appears in the RHR.'
       def query(db)
         db.from(left.evaluate(db))

--- a/lib/conceptql/operators/place_of_service_code.rb
+++ b/lib/conceptql/operators/place_of_service_code.rb
@@ -9,6 +9,8 @@ module ConceptQL
     # concept_name column of the concept table.  If you misspell the place_of_service_code name
     # you won't get any matches
     class PlaceOfServiceCode < Operator
+      register __FILE__
+
       desc 'Finds all visit_occurrences that match the Place of Service codes'
       argument :places_of_service, type: :codelist, vocab: 'Place of Service'
       types :visit_occurrence

--- a/lib/conceptql/operators/procedure_occurrence.rb
+++ b/lib/conceptql/operators/procedure_occurrence.rb
@@ -3,6 +3,8 @@ require_relative 'casting_operator'
 module ConceptQL
   module Operators
     class ProcedureOccurrence < CastingOperator
+      register __FILE__
+
       desc 'Generates all procedure_occurrence records, or, if fed a stream, fetches all procedure_occurrence records for the people represented in the incoming result set.'
       types :procedure_occurrence
       allows_one_upstream

--- a/lib/conceptql/operators/prodcode.rb
+++ b/lib/conceptql/operators/prodcode.rb
@@ -3,6 +3,8 @@ require_relative 'source_vocabulary_operator'
 module ConceptQL
   module Operators
     class Prodcode < SourceVocabularyOperator
+      register __FILE__
+
       desc 'Searches the drug_exposure table for all conditions with matching Prodcodes'
       argument :prodcodes, type: :codelist, vocab_id: '203'
       predominant_types :drug_exposure

--- a/lib/conceptql/operators/race.rb
+++ b/lib/conceptql/operators/race.rb
@@ -9,6 +9,8 @@ module ConceptQL
     # concept_name column of the concept table.  If you misspell the race name
     # you won't get any matches
     class Race < Operator
+      register __FILE__
+
       desc 'Finds all people that match the races'
       argument :races, type: :codelist, vocab: 'Race'
       types :person

--- a/lib/conceptql/operators/recall.rb
+++ b/lib/conceptql/operators/recall.rb
@@ -10,6 +10,8 @@ module ConceptQL
     # This operator will look for a sub-concept that has been created through the
     # "define" operator and will fetch the results cached in the corresponding table
     class Recall < Operator
+      register __FILE__
+
       desc <<-EOF
 Recalls a set of named results that were previously stored using the Define operator.
 Must be surrounded by the same Let operator as surrounds the corresponding Define operator.

--- a/lib/conceptql/operators/rxnorm.rb
+++ b/lib/conceptql/operators/rxnorm.rb
@@ -3,6 +3,8 @@ require_relative 'standard_vocabulary_operator'
 module ConceptQL
   module Operators
     class Rxnorm < StandardVocabularyOperator
+      register __FILE__
+
       preferred_name 'RxNorm'
       desc 'Finds all drug_exposures by RxNorm codes'
       argument :rxnorms, type: :codelist, vocab: 'RxNorm'

--- a/lib/conceptql/operators/snomed.rb
+++ b/lib/conceptql/operators/snomed.rb
@@ -3,6 +3,8 @@ require_relative 'standard_vocabulary_operator'
 module ConceptQL
   module Operators
     class Snomed < StandardVocabularyOperator
+      register __FILE__
+
       preferred_name 'SNOMED'
       desc 'Find all condition_occurrences by SNOMED codes'
       argument :snomeds, type: :codelist, vocab: 'SNOMED'

--- a/lib/conceptql/operators/snomed_condition.rb
+++ b/lib/conceptql/operators/snomed_condition.rb
@@ -3,6 +3,8 @@ require_relative 'standard_vocabulary_operator'
 module ConceptQL
   module Operators
     class SnomedCondition < StandardVocabularyOperator
+      register __FILE__
+
       preferred_name 'SNOMED'
       desc 'Find all condition_occurrences by SNOMED codes'
       argument :snomeds, type: :codelist, vocab: 'SNOMED'

--- a/lib/conceptql/operators/source_vocabulary_operator.rb
+++ b/lib/conceptql/operators/source_vocabulary_operator.rb
@@ -26,6 +26,8 @@ module ConceptQL
     #   * The vocabulary ID of the source vocabulary for the criterion
     #   * e.g. for ICD-9, a value of 2 (for ICD-9-CM)
     class SourceVocabularyOperator < Operator
+      register __FILE__
+
       category 'Source Vocabulary'
       category 'Code Lists'
 

--- a/lib/conceptql/operators/standard_vocabulary_operator.rb
+++ b/lib/conceptql/operators/standard_vocabulary_operator.rb
@@ -19,6 +19,8 @@ module ConceptQL
     #   * The vocabulary ID of the source vocabulary for the criterion
     #   * e.g. for CPT, a value of 4 (for CPT-4)
     class StandardVocabularyOperator < Operator
+      register __FILE__
+
       category 'Standard Vocabulary'
       category 'Code Lists'
       def query(db)

--- a/lib/conceptql/operators/started_by.rb
+++ b/lib/conceptql/operators/started_by.rb
@@ -3,6 +3,8 @@ require_relative 'temporal_operator'
 module ConceptQL
   module Operators
     class StartedBy < TemporalOperator
+      register __FILE__
+
       desc <<-EOF
 If LHR has the same start date as RHR, but LHR's end_date falls on or after end_date of RHR, LHR is passed through.
 L----Y----L

--- a/lib/conceptql/operators/sum.rb
+++ b/lib/conceptql/operators/sum.rb
@@ -3,6 +3,8 @@ require_relative 'pass_thru'
 module ConceptQL
   module Operators
     class Sum < PassThru
+      register __FILE__
+
       desc <<-EOF
 Sums value_as_number across all results that match on all but start_date, end_date.
 For start_date and end_date the min and max of each respectively is returned.'

--- a/lib/conceptql/operators/temporal_operator.rb
+++ b/lib/conceptql/operators/temporal_operator.rb
@@ -8,6 +8,8 @@ module ConceptQL
     # a proc that can be executed as a Sequel "virtual row" e.g.
     # Proc.new { l.end_date < r.start_date }
     class TemporalOperator < BinaryOperatorOperator
+      register __FILE__
+
       reset_categories
       category %w(Temporal Relative)
 

--- a/lib/conceptql/operators/time_window.rb
+++ b/lib/conceptql/operators/time_window.rb
@@ -20,6 +20,8 @@ module ConceptQL
     # pass '', '0', or nil as that argument.  E.g.:
     # start: 'd', end: '' # Only adjust start_date by positive 1 day and leave end_date uneffected
     class TimeWindow < Operator
+      register __FILE__
+
       desc 'Adjusts the start_date and end_date columns to create a new window of time for each result.'
       option :start, type: :string
       option :end, type: :string

--- a/lib/conceptql/operators/to_seer_visits.rb
+++ b/lib/conceptql/operators/to_seer_visits.rb
@@ -3,6 +3,8 @@ require_relative 'operator'
 module ConceptQL
   module Operators
     class ToSeerVisits < Operator
+      register __FILE__
+
       def type
         :visit_occurrence
       end

--- a/lib/conceptql/operators/trim_date_end.rb
+++ b/lib/conceptql/operators/trim_date_end.rb
@@ -13,6 +13,8 @@ module ConceptQL
     # If the RHS result's start_date is later than the LHS end_date, the LHS
     # result is passed thru unaffected.
     class TrimDateEnd < TemporalOperator
+      register __FILE__
+
       desc <<-EOF
 Trims the end_date of the LHS set of results by the RHS's earliest
 start_date (per person)

--- a/lib/conceptql/operators/trim_date_start.rb
+++ b/lib/conceptql/operators/trim_date_start.rb
@@ -13,6 +13,8 @@ module ConceptQL
     # If the RHS result's end_date is earlier than the LHS start_date, the LHS
     # result is passed thru unaffected.
     class TrimDateStart < TemporalOperator
+      register __FILE__
+
       desc <<-EOF
 Trims the start_date of the LHS set of results by the RHS's latest
 end_date (per person)

--- a/lib/conceptql/operators/union.rb
+++ b/lib/conceptql/operators/union.rb
@@ -3,6 +3,8 @@ require_relative 'pass_thru'
 module ConceptQL
   module Operators
     class Union < PassThru
+      register __FILE__
+
       desc 'Pools sets of incoming results into a single large set of results.'
       allows_many_upstreams
       category 'Set Logic'

--- a/lib/conceptql/operators/visit.rb
+++ b/lib/conceptql/operators/visit.rb
@@ -3,6 +3,8 @@ require_relative 'operator'
 module ConceptQL
   module Operators
     class Visit < Operator
+      register __FILE__
+
       desc 'Generates all visit_occurrence records, or, if fed a stream, fetches all visit_occurrence records for the people represented in the incoming result set.'
       types :visit_occurrence
       allows_one_upstream

--- a/lib/conceptql/operators/visit_occurrence.rb
+++ b/lib/conceptql/operators/visit_occurrence.rb
@@ -3,6 +3,8 @@ require_relative 'casting_operator'
 module ConceptQL
   module Operators
     class VisitOccurrence < CastingOperator
+      register __FILE__
+
       desc 'Returns all visits in the database, or if given a upstream, converts all results to the set of visit_occurrences related to those results.'
       allows_one_upstream
       types :visit_occurrence

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -96,7 +96,6 @@ shared_examples_for(:casting_operator) do
 end
 
 def require_double(double_name)
-  p = Pathname.new('.')
-  p = p + 'spec' + 'doubles' + (double_name + '_double')
-  require(p.expand_path)
+  p = File.join('.', 'spec', 'doubles', double_name + '_double')
+  require(File.expand_path(p))
 end


### PR DESCRIPTION
chdir is unsafe when running threaded code, and should not be called
by a library at runtime, and it looks like Nodifier.new is called at
runtime by Tree.new.

Additionally, if possible it's best to avoid requiring files at
runtime.  There doesn't seem to be a good reason to avoid requiring
all operators on initialization, so do that, and register the
operators in a hash. This way Nodifier does not need require all
operator files each time an instance is created.  Freeze the hash
of operators for thread safety.

This drops all dependency on facets from Nodifier, as well as
all dependency on Pathname.

One other change is that the operators hash is string keyed instead of
symbol keyed.  This makes it so you don't need to call to_sym in
Nodifier#create, which was probably a denial of service vulnerability
in ruby <2.2.

All of the operator files are modified in this commit, but it's just to
add a line to register the classes.  We may want to remove registrations
for abstract base classes, but I'm not sure which classes are abstract
base classes currently, other than Operator itself.