### PR TITLE
Optimize some Union operators

### DIFF
--- a/lib/conceptql/nodifier.rb
+++ b/lib/conceptql/nodifier.rb
@@ -3,10 +3,10 @@ require_relative 'operators/operator'
 module ConceptQL
   class Nodifier
     def create(scope, operator, *values)
-      unless operators[operator.to_s]
+      unless klass = operators[operator.to_s]
         raise "Can't find operator for '#{operator}' in #{operators.keys.sort}"
       end
-      operator = operators[operator].new(*values)
+      operator = klass.new(*values)
       operator.scope = scope
       operator
     end
@@ -18,7 +18,7 @@ module ConceptQL
     private
 
     def operators
-      Operator.operators
+      Operators.operators
     end
   end
 end

--- a/lib/conceptql/operators/operator.rb
+++ b/lib/conceptql/operators/operator.rb
@@ -63,6 +63,10 @@ module ConceptQL
         evaluate(db).sql
       end
 
+      def unionable?(other)
+        false
+      end
+
       def select_it(query, specific_type = nil)
         specific_type = type if specific_type.nil? && respond_to?(:type)
         q = query.select(*columns(query, specific_type))

--- a/lib/conceptql/operators/source_vocabulary_operator.rb
+++ b/lib/conceptql/operators/source_vocabulary_operator.rb
@@ -41,6 +41,16 @@ module ConceptQL
         table
       end
 
+      def unionable?(other)
+        other.is_a?(self.class)
+      end
+
+      def union(other)
+        n = dup
+        n.instance_variable_set(:@values, @values + other.values)
+        n
+      end
+
       private
 
       def table_name

--- a/lib/conceptql/operators/union.rb
+++ b/lib/conceptql/operators/union.rb
@@ -10,7 +10,23 @@ module ConceptQL
       category 'Set Logic'
 
       def query(db)
-        values.map do |expression|
+        first, *rest = values
+        exprs = [first]
+
+        rest.each do |expression|
+          add = true
+          exprs.length.times do |i|
+            exp = exprs[i]
+            if exprs[i].unionable?(expression)
+              exprs[i] = exp.union(expression)
+              add = false
+              break
+            end
+          end
+          exprs << expression if add
+        end
+
+        exprs.map do |expression|
           expression.evaluate(db).from_self
         end.inject do |q, query|
           q.union(query, all: true)


### PR DESCRIPTION
This optimizes Union operators that union multiple instances of
the same SourceVocabularyOperator subclass with different values.
    
This only results in a 10% speed improvement with the test data
(246ms vs 271ms).  However, the speed up will probably be larger for
larger datasets.  The previous unoptimized approach is going to run
separate scans for each of the branches of the union, so speed for
large datasets should be O(n*m), where n is the number of branches
in the union and m is the size of the dataset.  With this approach,
speed should be O(m) for large datasets.
    
I think it should be possible to extend this approach to optimizing
unions of separate SourceVocaularyOperator subclasses.  That's a
more important optimization, since it should handle many more cases
than this optimization.

This depends on the commit in pull request #3.