### PR TITLE
Add optimization for union of ICD9, ICD10, Medcode operators

### DIFF
--- a/lib/conceptql/operators/condition_occurrence_source_vocabulary_operator.rb
+++ b/lib/conceptql/operators/condition_occurrence_source_vocabulary_operator.rb
@@ -1,0 +1,41 @@
+require_relative 'source_vocabulary_operator'
+
+module ConceptQL
+  module Operators
+    class ConditionOccurrenceSourceVocabularyOperator < SourceVocabularyOperator
+      register __FILE__
+
+      preferred_name 'ICD-9 CM'
+      desc 'Searches the condition_occurrence table for the given set of ICD-9 codes.'
+      argument :icd9s, type: :codelist, vocab: 'ICD9CM'
+      predominant_types :condition_occurrence
+
+      def unionable?(other)
+        other.is_a?(ConditionOccurrenceSourceVocabularyOperator)
+      end
+
+      def union(other)
+        if other.is_a?(self.class)
+          dup_values(values + other.values)
+        elsif other.is_a?(ConditionOccurrenceSourceVocabularyOperatorUnion)
+          other.union(self)
+        else
+          ConditionOccurrenceSourceVocabularyOperatorUnion.new(self, other)
+        end
+      end
+
+      def table
+        :condition_occurrence
+      end
+
+      def source_column
+        :condition_source_value
+      end
+
+      def concept_column
+        :condition_concept_id
+      end
+    end
+  end
+end
+

--- a/lib/conceptql/operators/condition_occurrence_source_vocabulary_operator_union.rb
+++ b/lib/conceptql/operators/condition_occurrence_source_vocabulary_operator_union.rb
@@ -1,0 +1,35 @@
+require_relative 'condition_occurrence_source_vocabulary_operator'
+
+module ConceptQL
+  module Operators
+    class ConditionOccurrenceSourceVocabularyOperatorUnion < ConditionOccurrenceSourceVocabularyOperator
+      register __FILE__
+
+      #preferred_name ''
+      desc 'Searches the condition_occurrence table based on a union of multiple source vocabulary operators.'
+      #argument :source_vocabulary_operators, type: :codelist, vocab: ''
+      predominant_types :condition_occurrence
+
+      def union(other)
+        if other.is_a?(self.class)
+          dup_values(values + other.values)
+        else
+          same, different = values.partition{|x| x.is_a?(other.class)}
+          case same.length
+          when 0
+            dup_values(different + [other])
+          when 1
+            dup_values(different + [same.first.union(other)])
+          else
+            raise "multiple ConditionOccurrenceSourceVocabularyOperator subclass instances of same class in union"
+          end
+        end
+      end
+
+      def conditions
+        Sequel.|(*values.map(&:conditions))
+      end
+    end
+  end
+end
+

--- a/lib/conceptql/operators/icd10.rb
+++ b/lib/conceptql/operators/icd10.rb
@@ -1,8 +1,8 @@
-require_relative 'source_vocabulary_operator'
+require_relative 'condition_occurrence_source_vocabulary_operator'
 
 module ConceptQL
   module Operators
-    class Icd10 < SourceVocabularyOperator
+    class Icd10 < ConditionOccurrenceSourceVocabularyOperator
       register __FILE__
 
       preferred_name 'ICD-10 CM'
@@ -10,20 +10,8 @@ module ConceptQL
       argument :icd10s, type: :codelist, vocab: 'ICD10CM'
       predominant_types :condition_occurrence
 
-      def table
-        :condition_occurrence
-      end
-
       def vocabulary_id
         34
-      end
-
-      def source_column
-        :condition_source_value
-      end
-
-      def concept_column
-        :condition_concept_id
       end
     end
   end

--- a/lib/conceptql/operators/icd9.rb
+++ b/lib/conceptql/operators/icd9.rb
@@ -1,8 +1,8 @@
-require_relative 'source_vocabulary_operator'
+require_relative 'condition_occurrence_source_vocabulary_operator'
 
 module ConceptQL
   module Operators
-    class Icd9 < SourceVocabularyOperator
+    class Icd9 < ConditionOccurrenceSourceVocabularyOperator
       register __FILE__
 
       preferred_name 'ICD-9 CM'
@@ -10,20 +10,8 @@ module ConceptQL
       argument :icd9s, type: :codelist, vocab: 'ICD9CM'
       predominant_types :condition_occurrence
 
-      def table
-        :condition_occurrence
-      end
-
       def vocabulary_id
         2
-      end
-
-      def source_column
-        :condition_source_value
-      end
-
-      def concept_column
-        :condition_concept_id
       end
     end
   end

--- a/lib/conceptql/operators/medcode.rb
+++ b/lib/conceptql/operators/medcode.rb
@@ -1,28 +1,16 @@
-require_relative 'source_vocabulary_operator'
+require_relative 'condition_occurrence_source_vocabulary_operator'
 
 module ConceptQL
   module Operators
-    class Medcode < SourceVocabularyOperator
+    class Medcode < ConditionOccurrenceSourceVocabularyOperator
       register __FILE__
 
       desc 'Searches the condition_occurrence table for all conditions with matching Medcodes'
       argument :medcodes, type: :codelist, vocab_id: '203'
       predominant_types :condition_occurrence
 
-      def table
-        :condition_occurrence
-      end
-
       def vocabulary_id
         203
-      end
-
-      def source_column
-        :condition_source_value
-      end
-
-      def concept_column
-        :condition_concept_id
       end
     end
   end

--- a/lib/conceptql/operators/operator.rb
+++ b/lib/conceptql/operators/operator.rb
@@ -50,6 +50,12 @@ module ConceptQL
         @values = args
       end
 
+      def dup_values(args)
+        n = dup
+        n.set_values(*args)
+        n
+      end
+
       def scope=(scope)
         @scope = scope
         scope.add_operator(self)
@@ -61,6 +67,10 @@ module ConceptQL
 
       def sql(db)
         evaluate(db).sql
+      end
+
+      def optimized
+        dup_values(values.map{|x| x.is_a?(Operator) ? x.optimized : self})
       end
 
       def unionable?(other)

--- a/lib/conceptql/operators/operator.rb
+++ b/lib/conceptql/operators/operator.rb
@@ -51,9 +51,7 @@ module ConceptQL
       end
 
       def dup_values(args)
-        n = dup
-        n.set_values(*args)
-        n
+        self.class.new(*args)
       end
 
       def scope=(scope)
@@ -70,7 +68,7 @@ module ConceptQL
       end
 
       def optimized
-        dup_values(values.map{|x| x.is_a?(Operator) ? x.optimized : self})
+        dup_values(values.map{|x| x.is_a?(Operator) ? x.optimized : x})
       end
 
       def unionable?(other)

--- a/lib/conceptql/operators/source_vocabulary_operator.rb
+++ b/lib/conceptql/operators/source_vocabulary_operator.rb
@@ -33,8 +33,8 @@ module ConceptQL
 
       def query(db)
         db.from(table_name)
-          .join(:vocabulary__source_to_concept_map___scm, scm__target_concept_id: table_concept_column)
-          .where(Sequel.expr(scm__source_code: values, scm__source_vocabulary_id: vocabulary_id).&(Sequel.expr(scm__source_code: table_source_column)))
+          .join(:vocabulary__source_to_concept_map___scm, [[:scm__target_concept_id, table_concept_column], [:scm__source_code, table_source_column]])
+          .where(conditions)
       end
 
       def type
@@ -46,9 +46,11 @@ module ConceptQL
       end
 
       def union(other)
-        n = dup
-        n.instance_variable_set(:@values, @values + other.values)
-        n
+        dup_values(values + other.values)
+      end
+
+      def conditions
+        [[:scm__source_code, values], [:scm__source_vocabulary_id, vocabulary_id]]
       end
 
       private

--- a/lib/conceptql/operators/union.rb
+++ b/lib/conceptql/operators/union.rb
@@ -17,8 +17,20 @@ module ConceptQL
         end
       end
 
+      def flattened
+        exprs = []
+        values.each do |x|
+          if x.is_a?(Union)
+            exprs.concat x.flattened.values
+          else
+            exprs << x
+          end
+        end
+        dup_values(exprs)
+      end
+
       def optimized
-        first, *rest = values
+        first, *rest = flattened.values
         exprs = [first]
 
         rest.each do |expression|
@@ -34,7 +46,7 @@ module ConceptQL
           exprs << expression if add
         end
 
-        dup_values(exprs)
+        dup_values(exprs.map{|x| x.is_a?(Operator) ? x.optimized : x})
       end
     end
   end

--- a/lib/conceptql/operators/union.rb
+++ b/lib/conceptql/operators/union.rb
@@ -10,6 +10,14 @@ module ConceptQL
       category 'Set Logic'
 
       def query(db)
+        values.map do |expression|
+          expression.evaluate(db).from_self
+        end.inject do |q, query|
+          q.union(query, all: true)
+        end
+      end
+
+      def optimized
         first, *rest = values
         exprs = [first]
 
@@ -26,11 +34,7 @@ module ConceptQL
           exprs << expression if add
         end
 
-        exprs.map do |expression|
-          expression.evaluate(db).from_self
-        end.inject do |q, query|
-          q.union(query, all: true)
-        end
+        dup_values(exprs)
       end
     end
   end

--- a/lib/conceptql/query.rb
+++ b/lib/conceptql/query.rb
@@ -24,6 +24,12 @@ module ConceptQL
       (tree.scope.sql(db) << operator.sql(db)).join(";\n\n") + ';'
     end
 
+    def optimized
+      n = dup
+      n.instance_variable_set(:@operator, operator.optimized)
+      n
+    end
+
     def types
       tree.root(self).types
     end

--- a/spec/conceptql/operators/source_vocabulary_operator_spec.rb
+++ b/spec/conceptql/operators/source_vocabulary_operator_spec.rb
@@ -24,11 +24,31 @@ describe ConceptQL::Operators::SourceVocabularyOperator do
 
   describe '#query' do
     it 'works for single values' do
-      expect(SourceVocabularyDouble.new('value').query(Sequel.mock).sql).to eq("SELECT * FROM table AS tab INNER JOIN vocabulary.source_to_concept_map AS scm ON (scm.target_concept_id = tab.concept_column) WHERE ((scm.source_code IN ('value')) AND (scm.source_vocabulary_id = 1) AND (scm.source_code = tab.source_column))")
+      expect(SourceVocabularyDouble.new('value').query(Sequel.mock).sql).to eq("SELECT * FROM table AS tab INNER JOIN vocabulary.source_to_concept_map AS scm ON ((scm.target_concept_id = tab.concept_column) AND (scm.source_code = tab.source_column)) WHERE ((scm.source_code IN ('value')) AND (scm.source_vocabulary_id = 1))")
     end
 
     it 'works for multiple values' do
-      expect(SourceVocabularyDouble.new('value1', 'value2').query(Sequel.mock).sql).to eq("SELECT * FROM table AS tab INNER JOIN vocabulary.source_to_concept_map AS scm ON (scm.target_concept_id = tab.concept_column) WHERE ((scm.source_code IN ('value1', 'value2')) AND (scm.source_vocabulary_id = 1) AND (scm.source_code = tab.source_column))")
+      expect(SourceVocabularyDouble.new('value', 'value2').query(Sequel.mock).sql).to eq("SELECT * FROM table AS tab INNER JOIN vocabulary.source_to_concept_map AS scm ON ((scm.target_concept_id = tab.concept_column) AND (scm.source_code = tab.source_column)) WHERE ((scm.source_code IN ('value', 'value2')) AND (scm.source_vocabulary_id = 1))")
+    end
+
+    it 'supports union optimization' do
+      sql = lambda do |str|
+        "SELECT * FROM (SELECT person_id, condition_occurrence_id AS criterion_id, CAST('condition_occurrence' AS varchar(255)) AS criterion_type, CAST(condition_start_date AS date) AS start_date, coalesce(CAST(condition_end_date AS date), condition_start_date) AS end_date, CAST(NULL AS double precision) AS value_as_number, CAST(NULL AS varchar(255)) AS value_as_string, CAST(NULL AS integer) AS value_as_concept_id, CAST(NULL AS varchar(255)) AS units_source_value, CAST(condition_source_value AS varchar(255)) AS source_value FROM condition_occurrence AS tab INNER JOIN vocabulary.source_to_concept_map AS scm ON ((scm.target_concept_id = tab.condition_concept_id) AND (scm.source_code = tab.condition_source_value)) WHERE (#{str})) AS t1"
+      end
+
+      expect(ConceptQL::Operators::Union.new(ConceptQL::Operators::Icd9.new('value'), ConceptQL::Operators::Icd9.new('value2')).optimized.query(Sequel.mock).sql).to eq(sql["(scm.source_code IN ('value', 'value2')) AND (scm.source_vocabulary_id = 2)"])
+
+      expect(ConceptQL::Operators::Union.new(ConceptQL::Operators::Icd9.new('value'), ConceptQL::Operators::Icd10.new('value2')).optimized.query(Sequel.mock).sql).to eq(sql["((scm.source_code IN ('value')) AND (scm.source_vocabulary_id = 2)) OR ((scm.source_code IN ('value2')) AND (scm.source_vocabulary_id = 34))"])
+
+      expect(ConceptQL::Operators::Union.new(ConceptQL::Operators::Icd9.new('value'), ConceptQL::Operators::Icd10.new('value3'), ConceptQL::Operators::Icd9.new('value2')).optimized.query(Sequel.mock).sql).to eq(sql["((scm.source_code IN ('value3')) AND (scm.source_vocabulary_id = 34)) OR ((scm.source_code IN ('value', 'value2')) AND (scm.source_vocabulary_id = 2))"])
+
+      expect(ConceptQL::Operators::Union.new(ConceptQL::Operators::Icd9.new('value4'), ConceptQL::Operators::Union.new(ConceptQL::Operators::Icd9.new('value'), ConceptQL::Operators::Icd10.new('value3'), ConceptQL::Operators::Icd9.new('value2'))).optimized.query(Sequel.mock).sql).to eq(sql["((scm.source_code IN ('value3')) AND (scm.source_vocabulary_id = 34)) OR ((scm.source_code IN ('value4', 'value', 'value2')) AND (scm.source_vocabulary_id = 2))"])
+
+      expect(ConceptQL::Operators::Union.new(ConceptQL::Operators::Union.new(ConceptQL::Operators::Icd9.new('value'), ConceptQL::Operators::Icd10.new('value3'), ConceptQL::Operators::Icd9.new('value2')), ConceptQL::Operators::Icd9.new('value4')).optimized.query(Sequel.mock).sql).to eq(sql["((scm.source_code IN ('value3')) AND (scm.source_vocabulary_id = 34)) OR ((scm.source_code IN ('value', 'value2', 'value4')) AND (scm.source_vocabulary_id = 2))"])
+
+      expect(ConceptQL::Operators::Union.new(ConceptQL::Operators::Icd9.new('value4'), ConceptQL::Operators::Union.new(ConceptQL::Operators::Icd9.new('value'), ConceptQL::Operators::Icd10.new('value3')), ConceptQL::Operators::Icd9.new('value2')).optimized.query(Sequel.mock).sql).to eq(sql["((scm.source_code IN ('value3')) AND (scm.source_vocabulary_id = 34)) OR ((scm.source_code IN ('value4', 'value', 'value2')) AND (scm.source_vocabulary_id = 2))"])
+
+      expect(ConceptQL::Operators::Union.new(ConceptQL::Operators::Icd9.new('value4'), ConceptQL::Operators::Union.new(ConceptQL::Operators::Icd9.new('value'), ConceptQL::Operators::Union.new(ConceptQL::Operators::Icd10.new('value3'), ConceptQL::Operators::Icd9.new('value2')))).optimized.query(Sequel.mock).sql).to eq(sql["((scm.source_code IN ('value3')) AND (scm.source_vocabulary_id = 34)) OR ((scm.source_code IN ('value4', 'value', 'value2')) AND (scm.source_vocabulary_id = 2))"])
     end
   end
 end


### PR DESCRIPTION
Add optimization for union of ICD9, ICD10, Medcode operators

It's possible to optimize a union of these three cases to avoid
an SQL UNION ALL because they all join to the same table.

This adds a ConditionOccurrenceSourceVocabularyOperator subclass
for ICD9, ICD10, Medcode to subclass from.  This class can handle
unions of separate subclasses, by just ORing the conditions in
each of the subclasses.

To make things easier, this moves the scm.source_code =
condition_source_value from WHERE to JOIN ON, since that is the
same for each subclass. With this change the WHERE conditions for
multiple operators can just be joined with OR.
    
A ConditionOccurrenceSourceVocabularyOperatorUnion subclass is
added to handle a union of multiple
ConditionOccurrenceSourceVocabularyOperators.

Union#optimize will now flatten unions it contains when optimizing.
This fixes Operator#optimized to handle values that aren't
operators, which was a bug that was caught by the flattening of
unions.

Unfortunately, the tests I'm using only show about a 10% speedup
with this.  I actually couldn't find data in the test database
that used an icd10 or medcode.  However, I expect this speedup will
be much greater on databases like Impala that lack indexes.