### PR TITLE
Initial try at projection support

### DIFF
--- a/lib/conceptql/query.rb
+++ b/lib/conceptql/query.rb
@@ -8,6 +8,46 @@ module ConceptQL
     extend Forwardable
     def_delegators :prepped_query, :all, :count, :execute, :order
 
+    class Projection
+      attr :query
+
+      def inspect
+        "<#ConceptQL::Query::Projection#{'(cached)' if @cached} #{query.sql}>"
+      end
+
+      def all
+        if @cached
+          @all
+        else
+          query.all
+        end
+      end
+
+      def initialize(query, opts={})
+        @query = query
+        if @cached = opts.fetch(:cached, true)
+          @projection_ids = {}
+          @all = query.all do |h|
+            (@projection_ids[h[:criterion_type]] ||= []) << h[:criterion_id]
+          end
+        end
+      end
+
+      def project(type, *columns)
+        ds = query.db.from(type).select(*columns)
+        id_column = Sequel.identifier("#{type}_id")
+        if @cached
+          if ids = @projection_ids[type.to_s]
+            ds.where(id_column=>@projection_ids[type.to_s])
+          else
+            ds.where(false)
+          end
+        else
+          ds.where(id_column=>query.select(:criterion_id).where(:criterion_type=>type.to_s))
+        end
+      end
+    end
+
     attr :statement
     def initialize(db, statement, tree = Tree.new)
       @db = db
@@ -18,6 +58,10 @@ module ConceptQL
 
     def query
       build_query(db)
+    end
+
+    def projection(opts={})
+      Projection.new(query, opts)
     end
 
     def sql


### PR DESCRIPTION
This adds basic support for projections to ConceptQL.  Instead
of calling query, you call projection.  This returns a
ConceptQL::Query::Projection object, on which you can call
all to get all of the query's rows, or project to get all
rows from the related table.

By default, projections work in cached mode, where it records all
related ids in a hash.  You can pass :cached=>false to operate
in uncached mode, which will allow the same behavior, but
each projection will also result in running the main query again.

To select only specific columns from the related table, you pass
additional arguments to project.

This doesn't add support for projections to the ConceptQL
language.  It shouldn't be difficult to do that, but it's not
actually necessary, as you can run arbitrary projections on
a ConceptQL::Query object without knowing the projections you
want in advance.
