### PR TITLE
Add ConceptQL::AnnotateGrapher

### DIFF
--- a/lib/conceptql/annotate_grapher.rb
+++ b/lib/conceptql/annotate_grapher.rb
@@ -1,0 +1,112 @@
+require 'graphviz'
+require 'facets/string/titlecase'
+
+module ConceptQL
+  class AnnotateGrapher
+    def initialize(statement)
+      @statement = statement
+      @counter = 0
+      raise "statement not annotated" unless statement.last[:annotation]
+    end
+
+    def graph_it(file_path, opts={})
+      opts  = opts.merge( type: :digraph )
+      g = GraphViz.new(:G, opts)
+      root = traverse(g, @statement)
+
+      blank = g.add_nodes("_blank")
+      blank[:shape] = 'none'
+      blank[:height] = 0
+      blank[:label] = ''
+      blank[:fixedsize] = true
+      link_to(g, @statement, root, blank)
+
+      g.output(:pdf => file_path)
+    end
+
+    private
+
+    TYPE_COLORS = {
+      person: 'blue',
+      visit_occurrence: 'orange',
+      condition_occurrence: 'red',
+      procedure_occurrence: 'green3',
+      procedure_cost: 'gold',
+      death: 'brown',
+      payer_plan_period: 'blue',
+      drug_exposure: 'purple',
+      observation: 'magenta',
+      misc: 'black'
+    }
+
+    def type_color(*types)
+      types.flatten!
+      types.length == 1 ? TYPE_COLORS[types.first] || 'black' : 'black'
+    end
+
+    def types(op)
+      op.last[:annotation].keys
+    end
+
+    def link_to(g, from, from_node, to)
+      edge_options = {}
+
+      opts = from.last[:annotation]
+      types(from).each do |type|
+        n = opts[type][:n]
+        edge_options[:label] = " rows=#{opts[type][:rows]} \n n=#{n}"
+        edge_options[:style] = 'dashed' if n.zero?
+        e = g.add_edges(from_node, to, edge_options)
+        e[:color] = type_color(type)
+      end
+    end
+
+    def traverse(g, op)
+      op_name, *args, opts = op
+      upstreams, args = args.partition { |arg| arg.is_a?(Array) }
+      upstreams.map! do |upstream|
+        [upstream, traverse(g, upstream)]
+      end
+
+      if left = opts[:left]
+        right = opts[:right]
+        left_node = traverse(g, left)
+        right_node = traverse(g, right)
+      else
+        me = g.add_nodes(op_name)
+        me[:color] = type_color(*types(op))
+      end
+      label = opts[:name] || op_name.to_s.titlecase
+      label += ": #{args.join(', ')}" unless args.empty?
+      if label.length > 100
+        parts = label.split
+        label = parts.each_slice(label.length / parts.count).map do |subparts|
+          subparts.join(' ')
+        end.join ('\n')
+      end
+      exclude = [:annotation, :name, :left, :right]
+      label_opts = opts.reject{|k,_| exclude.include?(k)}
+      label += "\n#{label_opts.map{|k,v| "#{k}: #{v}"}.join("\n")}" unless label_opts.nil? || label_opts.empty?
+      label
+
+      upstreams.each do |upstream, node|
+        link_to(g, upstream, node, me)
+      end
+
+      if left_node
+        cluster_name = "cluster_#{op_name}_#{@counter += 1}"
+        me = g.send(cluster_name) do |sub|
+          sub[rank: 'same', label: label, color: 'black']
+          sub.send("#{cluster_name}_left").send('[]', shape: 'point', color: type_color(*types(op)))
+          sub.send("#{cluster_name}_right").send('[]', shape: 'point')
+        end
+        link_to(g, left, left_node, me.send("#{cluster_name}_left"))
+        link_to(g, right, right_node, me.send("#{cluster_name}_right"))
+        me = me.send("#{cluster_name}_left")
+      end
+
+      me[:label] = label
+      me
+    end
+  end
+end

--- a/lib/conceptql/operators/operator.rb
+++ b/lib/conceptql/operators/operator.rb
@@ -70,7 +70,11 @@ module ConceptQL
         types.each do |type|
           annotation[type] ||= {:rows=>0, :n=>0}
         end
-        res << metadata
+        if res.last.is_a?(Hash)
+          res.last.merge!(metadata)
+        else
+          res << metadata
+        end
 
         res
       end

--- a/spec/conceptql/query_spec.rb
+++ b/spec/conceptql/query_spec.rb
@@ -60,6 +60,9 @@ describe ConceptQL::Query do
         ["cpt", "99214", {:name=>"CPT", :annotation=>{:procedure_occurrence=>{:rows=>449428, :n=>81027}}}],
         {:annotation=>{:condition_occurrence=>{:rows=>19228, :n=>15936},
                        :procedure_occurrence=>{:rows=>449428, :n=>81027}}}])
+
+      expect(ConceptQL::Query.new(db, query.annotate).sql).to eq(query.sql)
+      expect(ConceptQL::Query.new(db, query.annotate).annotate).to eq(query.annotate)
     end
 
     it 'runs queries for binary operators ' do
@@ -89,18 +92,25 @@ describe ConceptQL::Query do
         after_sql])
       expect(res).to eq(["after",
         {:left=>["icd9", "412", {:name=>"ICD-9 CM", :annotation=>{:condition_occurrence=>{:rows=>19228, :n=>15936}}}],
-         :right=>["cpt", "99214", {:name=>"CPT", :annotation=>{:procedure_occurrence=>{:rows=>449428, :n=>81027}}}]},
-        {:annotation=>{:condition_occurrence=>{:rows=>19228, :n=>15936},
+         :right=>["cpt", "99214", {:name=>"CPT", :annotation=>{:procedure_occurrence=>{:rows=>449428, :n=>81027}}}],
+         :annotation=>{:condition_occurrence=>{:rows=>19228, :n=>15936},
                        :procedure_occurrence=>{:rows=>449428, :n=>81027}}}])
+
+      expect(ConceptQL::Query.new(db, query.annotate).sql).to eq(query.sql)
+      expect(ConceptQL::Query.new(db, query.annotate).annotate).to eq(query.annotate)
     end
 
     it 'handles no rows returned' do
-      query = ConceptQL::Query.new(Sequel.mock, {:union=>[{:icd9=>"412"}, {:cpt=>"99214"}]})
+      db = Sequel.mock
+      query = ConceptQL::Query.new(db, {:union=>[{:icd9=>"412"}, {:cpt=>"99214"}]})
       expect(query.annotate).to eq(["union",
         ["icd9", "412", {:name=>"ICD-9 CM", :annotation=>{:condition_occurrence=>{:rows=>0, :n=>0}}}],
         ["cpt", "99214", {:name=>"CPT", :annotation=>{:procedure_occurrence=>{:rows=>0, :n=>0}}}],
         {:annotation=>{:condition_occurrence=>{:rows=>0, :n=>0},
                        :procedure_occurrence=>{:rows=>0, :n=>0}}}])
+
+      expect(ConceptQL::Query.new(db, query.annotate).sql).to eq(query.sql)
+      expect(ConceptQL::Query.new(db, query.annotate).annotate).to eq(query.annotate)
     end
   end
 end


### PR DESCRIPTION
This takes output from Query#annotate and builds a Graphviz diagram,
without having access to a database.  This will eventually allow
the removal of graphing code from operators, Graph, GraphNodifier,
and potentially other places.
    
No tests yet as currently the only output is PDF.

Also, handle annotations for operators using hashes.