### PR TITLE
Allow rake test_db_setup to work on Impala

### DIFF
--- a/test/db.rb
+++ b/test/db.rb
@@ -12,7 +12,7 @@ END
   exit 1
 end
 
-unless DB.opts[:database] =~ /test/
+if DB.opts[:database] && DB.opts[:database] !~ /test/
   $stderr.puts <<END
 The test database name doesn't include the substring "test".
 Exiting now to avoid potential modification of non-test database.

--- a/test/operators/person_filter_test.rb
+++ b/test/operators/person_filter_test.rb
@@ -24,7 +24,7 @@ describe ConceptQL::Operators::PersonFilter do
         },
         right: { gender: 'Male' }
       }
-    ).must_equal("condition_occurrence"=>56, "procedure_occurrence"=>609)
+    ).must_equal("condition_occurrence"=>28, "procedure_occurrence"=>609)
 
     criteria_ids(
       person_filter: {


### PR DESCRIPTION
There is no implicit casting of literals to numbers or varchar,
so this adds explicit casts to the type of the column. It also
allows rake test_db_setup to be run multiple times without
inserting duplicate data.

Impala can't handle inserting all test data in a single query,
so add a :slice option to Dataset#import.  A recent change I
committed to sequel-impala allows Dataset#import on Impala to
insert multiple rows at once, which speeds up the import
process by multiple orders of magnitude.

This also fixes the one test failure on PostgreSQL, which was
because I didn't take into account the duplicate data in
test_conceptql.