### PR TITLE
Add infrastructure for supporting multiple data models

### DIFF
--- a/lib/conceptql/nodifier.rb
+++ b/lib/conceptql/nodifier.rb
@@ -2,10 +2,11 @@ require_relative 'operators/operator'
 
 module ConceptQL
   class Nodifier
-    attr :tree, :algorithm_fetcher
+    attr :tree, :data_model, :algorithm_fetcher
 
     def initialize(tree, opts={})
       @tree = tree
+      @data_model = opts[:data_model] || :omopv4
       @algorithm_fetcher = opts[:algorithm_fetcher] || (proc do |alg|
         nil
       end)
@@ -33,7 +34,7 @@ module ConceptQL
     private
 
     def operators
-      Operators.operators
+      @operators ||= Operators.operators[@data_model]
     end
   end
 end

--- a/lib/conceptql/operators/after.rb
+++ b/lib/conceptql/operators/after.rb
@@ -3,7 +3,7 @@ require_relative 'temporal_operator'
 module ConceptQL
   module Operators
     class After < TemporalOperator
-      register __FILE__
+      register __FILE__, :omopv4
 
       desc <<-EOF
 Compares all results on a person-by-person basis between the left hand results (LHR) and the right hand resuls (RHR).

--- a/lib/conceptql/operators/any_overlap.rb
+++ b/lib/conceptql/operators/any_overlap.rb
@@ -3,7 +3,7 @@ require_relative 'temporal_operator'
 module ConceptQL
   module Operators
     class AnyOverlap < TemporalOperator
-      register __FILE__
+      register __FILE__, :omopv4
 
       desc 'If a result from the LHR overlaps in any way a result from the RHR it is passed along.'
       def where_clause

--- a/lib/conceptql/operators/before.rb
+++ b/lib/conceptql/operators/before.rb
@@ -3,7 +3,7 @@ require_relative 'temporal_operator'
 module ConceptQL
   module Operators
     class Before < TemporalOperator
-      register __FILE__
+      register __FILE__, :omopv4
 
       desc <<-EOF
 Compares all results on a person-by-person basis between the left hand results (LHR) and the right hand resuls (RHR).

--- a/lib/conceptql/operators/binary_operator_operator.rb
+++ b/lib/conceptql/operators/binary_operator_operator.rb
@@ -5,8 +5,6 @@ module ConceptQL
   module Operators
     # Base class for all operators that take two streams, a left-hand and a right-hand
     class BinaryOperatorOperator < Operator
-      register __FILE__
-
       option :left, type: :upstream
       option :right, type: :upstream
 

--- a/lib/conceptql/operators/casting_operator.rb
+++ b/lib/conceptql/operators/casting_operator.rb
@@ -23,8 +23,6 @@ module ConceptQL
     # Also, if a casting operator is passed no streams, it will return all the
     # rows in its table as results.
     class CastingOperator < Operator
-      register __FILE__
-
       category 'Casting'
       def types
         [type]

--- a/lib/conceptql/operators/complement.rb
+++ b/lib/conceptql/operators/complement.rb
@@ -3,7 +3,7 @@ require_relative 'pass_thru'
 module ConceptQL
   module Operators
     class Complement < PassThru
-      register __FILE__
+      register __FILE__, :omopv4
 
       desc 'Splits up the incoming result set by type and passes through all results for each type that are NOT in the current set.'
       allows_one_upstream

--- a/lib/conceptql/operators/condition_occurrence_source_vocabulary_operator.rb
+++ b/lib/conceptql/operators/condition_occurrence_source_vocabulary_operator.rb
@@ -3,8 +3,6 @@ require_relative 'source_vocabulary_operator'
 module ConceptQL
   module Operators
     class ConditionOccurrenceSourceVocabularyOperator < SourceVocabularyOperator
-      register __FILE__
-
       def unionable?(other)
         other.is_a?(ConditionOccurrenceSourceVocabularyOperator)
       end

--- a/lib/conceptql/operators/condition_occurrence_source_vocabulary_operator_union.rb
+++ b/lib/conceptql/operators/condition_occurrence_source_vocabulary_operator_union.rb
@@ -3,8 +3,6 @@ require_relative 'condition_occurrence_source_vocabulary_operator'
 module ConceptQL
   module Operators
     class ConditionOccurrenceSourceVocabularyOperatorUnion < ConditionOccurrenceSourceVocabularyOperator
-      register __FILE__
-
       def union(other)
         if other.is_a?(self.class)
           dup_values(values + other.values)

--- a/lib/conceptql/operators/condition_type.rb
+++ b/lib/conceptql/operators/condition_type.rb
@@ -10,7 +10,7 @@ module ConceptQL
     #
     # Multiple types can be specified at once
     class ConditionType < Operator
-      register __FILE__
+      register __FILE__, :omopv4
 
       desc 'Searches for conditions that match the given set of Condition Types'
       argument :condition_types, type: :codelist, vocab: 'Condition Type'

--- a/lib/conceptql/operators/contains.rb
+++ b/lib/conceptql/operators/contains.rb
@@ -3,7 +3,7 @@ require_relative 'temporal_operator'
 module ConceptQL
   module Operators
     class Contains < TemporalOperator
-      register __FILE__
+      register __FILE__, :omopv4
 
       desc <<-EOF
 Any result in the LHR whose start_date is on or before and whose end_date is on or after a result from the RHR.

--- a/lib/conceptql/operators/count.rb
+++ b/lib/conceptql/operators/count.rb
@@ -3,7 +3,7 @@ require_relative 'pass_thru'
 module ConceptQL
   module Operators
     class Count < PassThru
-      register __FILE__
+      register __FILE__, :omopv4
 
       desc 'Counts the number of results the exactly match across all columns.'
       allows_one_upstream

--- a/lib/conceptql/operators/cpt.rb
+++ b/lib/conceptql/operators/cpt.rb
@@ -3,7 +3,7 @@ require_relative 'standard_vocabulary_operator'
 module ConceptQL
   module Operators
     class Cpt < StandardVocabularyOperator
-      register __FILE__
+      register __FILE__, :omopv4
 
       preferred_name 'CPT'
       desc 'Searches the procedure_occurrence table for all procedures with matching CPT codes'

--- a/lib/conceptql/operators/date_range.rb
+++ b/lib/conceptql/operators/date_range.rb
@@ -8,7 +8,7 @@ module ConceptQL
     # 'START' represents the first date of data in the data source,
     # 'END' represents the last date of data in the data source,
     class DateRange < Operator
-      register __FILE__
+      register __FILE__, :omopv4
 
       desc 'Used to represent a date literal.'
       option :start, type: :string

--- a/lib/conceptql/operators/death.rb
+++ b/lib/conceptql/operators/death.rb
@@ -3,7 +3,7 @@ require_relative 'casting_operator'
 module ConceptQL
   module Operators
     class Death < CastingOperator
-      register __FILE__
+      register __FILE__, :omopv4
 
       desc 'Generates all death records, or, if fed a stream, fetches all death records for the people represented in the incoming result set.'
       types :death

--- a/lib/conceptql/operators/drug_type_concept.rb
+++ b/lib/conceptql/operators/drug_type_concept.rb
@@ -3,7 +3,7 @@ require_relative 'operator'
 module ConceptQL
   module Operators
     class DrugTypeConcept < Operator
-      register __FILE__
+      register __FILE__, :omopv4
 
       desc 'Given a set of concept IDs in RxNorm, returns that set of drug exposures'
       argument :concept_ids, type: :codelist, vocab: 'RxNorm'

--- a/lib/conceptql/operators/during.rb
+++ b/lib/conceptql/operators/during.rb
@@ -3,7 +3,7 @@ require_relative 'temporal_operator'
 module ConceptQL
   module Operators
     class During < TemporalOperator
-      register __FILE__
+      register __FILE__, :omopv4
 
       desc <<-EOF
 Compares all results on a person-by-person basis between the left hand results (LHR) and the right hand resuls (RHR).

--- a/lib/conceptql/operators/equal.rb
+++ b/lib/conceptql/operators/equal.rb
@@ -3,7 +3,7 @@ require_relative 'temporal_operator'
 module ConceptQL
   module Operators
     class Equal < TemporalOperator
-      register __FILE__
+      register __FILE__, :omopv4
 
       desc 'If a LHR result has the same value_as_number as a RHR result, it is passed through'
 

--- a/lib/conceptql/operators/except.rb
+++ b/lib/conceptql/operators/except.rb
@@ -3,7 +3,7 @@ require_relative 'binary_operator_operator'
 module ConceptQL
   module Operators
     class Except < BinaryOperatorOperator
-      register __FILE__
+      register __FILE__, :omopv4
 
       desc 'If a LHR result appears in the RHR result, it is removed from the output result set.'
       category 'Set Logic'

--- a/lib/conceptql/operators/filter.rb
+++ b/lib/conceptql/operators/filter.rb
@@ -3,7 +3,7 @@ require_relative 'binary_operator_operator'
 module ConceptQL
   module Operators
     class Filter < BinaryOperatorOperator
-      register __FILE__
+      register __FILE__, :omopv4
 
       desc 'Only pass through results from the LHR that have a corresponding RHR with the same person, criterion_id, and criterion_type'
 

--- a/lib/conceptql/operators/first.rb
+++ b/lib/conceptql/operators/first.rb
@@ -15,7 +15,7 @@ module ConceptQL
     # If we ask for the first occurrence of something and a person has no
     # occurrences, this operator returns nothing for that person
     class First < Occurrence
-      register __FILE__
+      register __FILE__, :omopv4
 
       desc 'Only passes through the row with the earliest start_date per person.  If more than one row qualifies, result is arbitrarily chosen.'
 

--- a/lib/conceptql/operators/from.rb
+++ b/lib/conceptql/operators/from.rb
@@ -3,7 +3,7 @@ require_relative 'pass_thru'
 module ConceptQL
   module Operators
     class From < Operator
-      register __FILE__
+      register __FILE__, :omopv4
 
       def query(db)
         db.from(values.first)

--- a/lib/conceptql/operators/from_seer_visits.rb
+++ b/lib/conceptql/operators/from_seer_visits.rb
@@ -3,7 +3,7 @@ require_relative 'operator'
 module ConceptQL
   module Operators
     class FromSeerVisits < Operator
-      register __FILE__
+      register __FILE__, :omopv4
 
       def type
         :observation

--- a/lib/conceptql/operators/gender.rb
+++ b/lib/conceptql/operators/gender.rb
@@ -3,7 +3,7 @@ require_relative 'operator'
 module ConceptQL
   module Operators
     class Gender < Operator
-      register __FILE__
+      register __FILE__, :omopv4
 
       desc 'Returns all person records that match the selected gender.'
       argument :gender, type: :string, options: ['Male', 'Female']

--- a/lib/conceptql/operators/hcpcs.rb
+++ b/lib/conceptql/operators/hcpcs.rb
@@ -3,7 +3,7 @@ require_relative 'standard_vocabulary_operator'
 module ConceptQL
   module Operators
     class Hcpcs < StandardVocabularyOperator
-      register __FILE__
+      register __FILE__, :omopv4
 
       preferred_name 'HCPCS'
       desc 'Searches the procedure_occurrence table for all procedures with matching HCPCS codes'

--- a/lib/conceptql/operators/icd10.rb
+++ b/lib/conceptql/operators/icd10.rb
@@ -3,7 +3,7 @@ require_relative 'condition_occurrence_source_vocabulary_operator'
 module ConceptQL
   module Operators
     class Icd10 < ConditionOccurrenceSourceVocabularyOperator
-      register __FILE__
+      register __FILE__, :omopv4
 
       preferred_name 'ICD-10 CM'
       desc 'Searches the condition_occurrence table for the given set of ICD-10 codes.'

--- a/lib/conceptql/operators/icd9.rb
+++ b/lib/conceptql/operators/icd9.rb
@@ -3,7 +3,7 @@ require_relative 'condition_occurrence_source_vocabulary_operator'
 module ConceptQL
   module Operators
     class Icd9 < ConditionOccurrenceSourceVocabularyOperator
-      register __FILE__
+      register __FILE__, :omopv4
 
       preferred_name 'ICD-9 CM'
       desc 'Searches the condition_occurrence table for the given set of ICD-9 codes.'

--- a/lib/conceptql/operators/icd9_procedure.rb
+++ b/lib/conceptql/operators/icd9_procedure.rb
@@ -3,7 +3,7 @@ require_relative 'standard_vocabulary_operator'
 module ConceptQL
   module Operators
     class Icd9Procedure < StandardVocabularyOperator
-      register __FILE__
+      register __FILE__, :omopv4
 
       preferred_name 'ICD-9 Proc'
       desc 'Searches the procedure_occurrence table for the given set of ICD-9 codes.'

--- a/lib/conceptql/operators/intersect.rb
+++ b/lib/conceptql/operators/intersect.rb
@@ -3,7 +3,7 @@ require_relative 'pass_thru'
 module ConceptQL
   module Operators
     class Intersect < PassThru
-      register __FILE__
+      register __FILE__, :omopv4
 
       desc 'Passes thru any result row that appears in all incoming result sets.'
       allows_many_upstreams

--- a/lib/conceptql/operators/last.rb
+++ b/lib/conceptql/operators/last.rb
@@ -15,7 +15,7 @@ module ConceptQL
     # If we ask for the last occurrence of something and a person has no
     # occurrences, this operator returns nothing for that person
     class Last < Occurrence
-      register __FILE__
+      register __FILE__, :omopv4
 
       desc 'Only passes through the row with the most recent start_date per person.  If more than one row qualifies, result is arbitrarily chosen.'
 

--- a/lib/conceptql/operators/loinc.rb
+++ b/lib/conceptql/operators/loinc.rb
@@ -3,7 +3,7 @@ require_relative 'standard_vocabulary_operator'
 module ConceptQL
   module Operators
     class Loinc < StandardVocabularyOperator
-      register __FILE__
+      register __FILE__, :omopv4
 
       preferred_name 'LOINC'
       desc 'Searches the observation table for all observations with matching LOINC codes'

--- a/lib/conceptql/operators/medcode.rb
+++ b/lib/conceptql/operators/medcode.rb
@@ -3,7 +3,7 @@ require_relative 'condition_occurrence_source_vocabulary_operator'
 module ConceptQL
   module Operators
     class Medcode < ConditionOccurrenceSourceVocabularyOperator
-      register __FILE__
+      register __FILE__, :omopv4
 
       desc 'Searches the condition_occurrence table for all conditions with matching Medcodes'
       argument :medcodes, type: :codelist, vocab_id: '203'

--- a/lib/conceptql/operators/medcode_procedure.rb
+++ b/lib/conceptql/operators/medcode_procedure.rb
@@ -3,7 +3,7 @@ require_relative 'source_vocabulary_operator'
 module ConceptQL
   module Operators
     class MedcodeProcedure < SourceVocabularyOperator
-      register __FILE__
+      register __FILE__, :omopv4
 
       desc 'Searches the procedure_occurrence table for all procedures with matching Medcodes'
       argument :medcodes, type: :codelist, vocab: '204'

--- a/lib/conceptql/operators/ndc.rb
+++ b/lib/conceptql/operators/ndc.rb
@@ -3,7 +3,7 @@ require_relative 'source_vocabulary_operator'
 module ConceptQL
   module Operators
     class Ndc < SourceVocabularyOperator
-      register __FILE__
+      register __FILE__, :omopv4
 
       preferred_name 'NDC'
       desc 'Searches the drug_exposure table for all procedures with matching NDC codes'

--- a/lib/conceptql/operators/numeric.rb
+++ b/lib/conceptql/operators/numeric.rb
@@ -12,7 +12,7 @@ module ConceptQL
     # - Either a number value or a symbol representing a column name
     # - An optional stream
     class Numeric < PassThru
-      register __FILE__
+      register __FILE__, :omopv4
 
       desc <<-EOF
 Represents a operator that will either:

--- a/lib/conceptql/operators/observation_by_enttype.rb
+++ b/lib/conceptql/operators/observation_by_enttype.rb
@@ -3,7 +3,7 @@ require_relative 'source_vocabulary_operator'
 module ConceptQL
   module Operators
     class ObservationByEnttype < SourceVocabularyOperator
-      register __FILE__
+      register __FILE__, :omopv4
 
       desc 'Searches the observation table for all observations with matching Enttype'
       argument :enttypes, type: :codelist, vocab_id: [206, 207]

--- a/lib/conceptql/operators/observation_period.rb
+++ b/lib/conceptql/operators/observation_period.rb
@@ -3,7 +3,7 @@ require_relative 'casting_operator'
 module ConceptQL
   module Operators
     class ObservationPeriod < CastingOperator
-      register __FILE__
+      register __FILE__, :omopv4
 
       desc 'Generates all observation_period records, or, if fed a stream, fetches all observation_period records for the people represented in the incoming result set.'
       types :observation_period

--- a/lib/conceptql/operators/occurrence.rb
+++ b/lib/conceptql/operators/occurrence.rb
@@ -22,7 +22,7 @@ module ConceptQL
     # If we ask for the second occurrence of something and a person has only one
     # occurrence, this operator returns nothing for that person
     class Occurrence < Operator
-      register __FILE__
+      register __FILE__, :omopv4
 
       preferred_name 'Nth Occurrence'
       desc <<-EOF

--- a/lib/conceptql/operators/one_in_two_out.rb
+++ b/lib/conceptql/operators/one_in_two_out.rb
@@ -4,7 +4,7 @@ require_relative 'visit_occurrence'
 module ConceptQL
   module Operators
     class OneInTwoOut < Operator
-      register __FILE__
+      register __FILE__, :omopv4
 
       desc <<-EOF
 Represents a common pattern in research algorithms: searching for a condition

--- a/lib/conceptql/operators/operator.rb
+++ b/lib/conceptql/operators/operator.rb
@@ -6,7 +6,7 @@ require 'forwardable'
 
 module ConceptQL
   module Operators
-    OPERATORS = {}
+    OPERATORS = {:omopv4=>{}}.freeze
 
     def self.operators
       OPERATORS
@@ -32,8 +32,10 @@ module ConceptQL
 
       option :label, type: :string
 
-      def self.register(file)
-        OPERATORS[File.basename(file).sub(/\.rb\z/, '')] = self
+      def self.register(file, *data_models)
+        data_models.each do |dm|
+          OPERATORS[dm][File.basename(file).sub(/\.rb\z/, '')] = self
+        end
       end
 
       def initialize(*args)
@@ -310,5 +312,4 @@ end
 Dir.new(File.dirname(__FILE__)).
   entries.
   each{|filename| require_relative filename if filename =~ /\.rb\z/ && filename != File.basename(__FILE__)}
-ConceptQL::Operators::OPERATORS['snomed_condition'] = ConceptQL::Operators::Snomed
-ConceptQL::Operators.operators.freeze
+ConceptQL::Operators.operators.values.each(&:freeze)

--- a/lib/conceptql/operators/overlapped_by.rb
+++ b/lib/conceptql/operators/overlapped_by.rb
@@ -3,7 +3,7 @@ require_relative 'temporal_operator'
 module ConceptQL
   module Operators
     class OverlappedBy < TemporalOperator
-      register __FILE__
+      register __FILE__, :omopv4
 
       desc <<-EOF
 Compares all results on a person-by-person basis between the left hand results (LHR) and the right hand resuls (RHR).

--- a/lib/conceptql/operators/overlaps.rb
+++ b/lib/conceptql/operators/overlaps.rb
@@ -3,7 +3,7 @@ require_relative 'temporal_operator'
 module ConceptQL
   module Operators
     class Overlaps < TemporalOperator
-      register __FILE__
+      register __FILE__, :omopv4
 
       desc <<-EOF
 Compares all results on a person-by-person basis between the left hand results (LHR) and the right hand resuls (RHR).

--- a/lib/conceptql/operators/pass_thru.rb
+++ b/lib/conceptql/operators/pass_thru.rb
@@ -3,7 +3,7 @@ require_relative 'operator'
 module ConceptQL
   module Operators
     class PassThru < Operator
-      register __FILE__
+      register __FILE__, :omopv4
 
       def types
         upstreams.map(&:types).flatten.uniq

--- a/lib/conceptql/operators/person.rb
+++ b/lib/conceptql/operators/person.rb
@@ -3,7 +3,7 @@ require_relative 'casting_operator'
 module ConceptQL
   module Operators
     class Person < CastingOperator
-      register __FILE__
+      register __FILE__, :omopv4
 
       desc 'Returns all people in the database, or if given a upstream, converts all results to the set of patients contained in those results.'
       allows_one_upstream

--- a/lib/conceptql/operators/person_filter.rb
+++ b/lib/conceptql/operators/person_filter.rb
@@ -3,7 +3,7 @@ require_relative 'binary_operator_operator'
 module ConceptQL
   module Operators
     class PersonFilter < BinaryOperatorOperator
-      register __FILE__
+      register __FILE__, :omopv4
 
       desc 'Only passes through a result from the LHR if the person appears in the RHR.'
       def query(db)

--- a/lib/conceptql/operators/place_of_service_code.rb
+++ b/lib/conceptql/operators/place_of_service_code.rb
@@ -9,7 +9,7 @@ module ConceptQL
     # concept_name column of the concept table.  If you misspell the place_of_service_code name
     # you won't get any matches
     class PlaceOfServiceCode < Operator
-      register __FILE__
+      register __FILE__, :omopv4
 
       desc 'Finds all visit_occurrences that match the Place of Service codes'
       argument :places_of_service, type: :codelist, vocab: 'Place of Service'

--- a/lib/conceptql/operators/procedure_occurrence.rb
+++ b/lib/conceptql/operators/procedure_occurrence.rb
@@ -3,7 +3,7 @@ require_relative 'casting_operator'
 module ConceptQL
   module Operators
     class ProcedureOccurrence < CastingOperator
-      register __FILE__
+      register __FILE__, :omopv4
 
       desc 'Generates all procedure_occurrence records, or, if fed a stream, fetches all procedure_occurrence records for the people represented in the incoming result set.'
       types :procedure_occurrence

--- a/lib/conceptql/operators/prodcode.rb
+++ b/lib/conceptql/operators/prodcode.rb
@@ -3,7 +3,7 @@ require_relative 'source_vocabulary_operator'
 module ConceptQL
   module Operators
     class Prodcode < SourceVocabularyOperator
-      register __FILE__
+      register __FILE__, :omopv4
 
       desc 'Searches the drug_exposure table for all conditions with matching Prodcodes'
       argument :prodcodes, type: :codelist, vocab_id: '203'

--- a/lib/conceptql/operators/race.rb
+++ b/lib/conceptql/operators/race.rb
@@ -9,7 +9,7 @@ module ConceptQL
     # concept_name column of the concept table.  If you misspell the race name
     # you won't get any matches
     class Race < Operator
-      register __FILE__
+      register __FILE__, :omopv4
 
       desc 'Finds all people that match the races'
       argument :races, type: :codelist, vocab: 'Race'

--- a/lib/conceptql/operators/recall.rb
+++ b/lib/conceptql/operators/recall.rb
@@ -10,7 +10,7 @@ module ConceptQL
     # This operator will look for a sub-concept that has been created through the
     # "define" operator and will fetch the results cached in the corresponding table
     class Recall < Operator
-      register __FILE__
+      register __FILE__, :omopv4
 
       desc <<-EOF
 Recalls a set of named results that were previously stored using the Define operator.

--- a/lib/conceptql/operators/rxnorm.rb
+++ b/lib/conceptql/operators/rxnorm.rb
@@ -3,7 +3,7 @@ require_relative 'standard_vocabulary_operator'
 module ConceptQL
   module Operators
     class Rxnorm < StandardVocabularyOperator
-      register __FILE__
+      register __FILE__, :omopv4
 
       preferred_name 'RxNorm'
       desc 'Finds all drug_exposures by RxNorm codes'

--- a/lib/conceptql/operators/snomed.rb
+++ b/lib/conceptql/operators/snomed.rb
@@ -3,7 +3,8 @@ require_relative 'standard_vocabulary_operator'
 module ConceptQL
   module Operators
     class Snomed < StandardVocabularyOperator
-      register __FILE__
+      register __FILE__, :omopv4
+      register __FILE__.sub("snomed", "snomed_condition"), :omopv4
 
       preferred_name 'SNOMED'
       desc 'Find all condition_occurrences by SNOMED codes'

--- a/lib/conceptql/operators/source_vocabulary_operator.rb
+++ b/lib/conceptql/operators/source_vocabulary_operator.rb
@@ -26,8 +26,6 @@ module ConceptQL
     #   * The vocabulary ID of the source vocabulary for the criterion
     #   * e.g. for ICD-9, a value of 2 (for ICD-9-CM)
     class SourceVocabularyOperator < Operator
-      register __FILE__
-
       category 'Source Vocabulary'
       category 'Code Lists'
 

--- a/lib/conceptql/operators/standard_vocabulary_operator.rb
+++ b/lib/conceptql/operators/standard_vocabulary_operator.rb
@@ -19,8 +19,6 @@ module ConceptQL
     #   * The vocabulary ID of the source vocabulary for the criterion
     #   * e.g. for CPT, a value of 4 (for CPT-4)
     class StandardVocabularyOperator < Operator
-      register __FILE__
-
       category 'Standard Vocabulary'
       category 'Code Lists'
       def query(db)

--- a/lib/conceptql/operators/started_by.rb
+++ b/lib/conceptql/operators/started_by.rb
@@ -3,7 +3,7 @@ require_relative 'temporal_operator'
 module ConceptQL
   module Operators
     class StartedBy < TemporalOperator
-      register __FILE__
+      register __FILE__, :omopv4
 
       desc <<-EOF
 If LHR has the same start date as RHR, but LHR's end_date falls on or after end_date of RHR, LHR is passed through.

--- a/lib/conceptql/operators/sum.rb
+++ b/lib/conceptql/operators/sum.rb
@@ -3,7 +3,7 @@ require_relative 'pass_thru'
 module ConceptQL
   module Operators
     class Sum < PassThru
-      register __FILE__
+      register __FILE__, :omopv4
 
       desc <<-EOF
 Sums value_as_number across all results that match on all but start_date, end_date.

--- a/lib/conceptql/operators/temporal_operator.rb
+++ b/lib/conceptql/operators/temporal_operator.rb
@@ -7,8 +7,6 @@ module ConceptQL
     # Subclasses must implement the where_clause method which should probably return
     # a Sequel expression to use for filtering.
     class TemporalOperator < BinaryOperatorOperator
-      register __FILE__
-
       reset_categories
       category %w(Temporal Relative)
 

--- a/lib/conceptql/operators/time_window.rb
+++ b/lib/conceptql/operators/time_window.rb
@@ -20,7 +20,7 @@ module ConceptQL
     # pass '', '0', or nil as that argument.  E.g.:
     # start: 'd', end: '' # Only adjust start_date by positive 1 day and leave end_date uneffected
     class TimeWindow < Operator
-      register __FILE__
+      register __FILE__, :omopv4
 
       desc 'Adjusts the start_date and end_date columns to create a new window of time for each result.'
       option :start, type: :string

--- a/lib/conceptql/operators/to_seer_visits.rb
+++ b/lib/conceptql/operators/to_seer_visits.rb
@@ -3,7 +3,7 @@ require_relative 'operator'
 module ConceptQL
   module Operators
     class ToSeerVisits < Operator
-      register __FILE__
+      register __FILE__, :omopv4
 
       def type
         :visit_occurrence

--- a/lib/conceptql/operators/trim_date_end.rb
+++ b/lib/conceptql/operators/trim_date_end.rb
@@ -13,7 +13,7 @@ module ConceptQL
     # If the RHS result's start_date is later than the LHS end_date, the LHS
     # result is passed thru unaffected.
     class TrimDateEnd < TemporalOperator
-      register __FILE__
+      register __FILE__, :omopv4
 
       desc <<-EOF
 Trims the end_date of the LHS set of results by the RHS's earliest

--- a/lib/conceptql/operators/trim_date_start.rb
+++ b/lib/conceptql/operators/trim_date_start.rb
@@ -13,7 +13,7 @@ module ConceptQL
     # If the RHS result's end_date is earlier than the LHS start_date, the LHS
     # result is passed thru unaffected.
     class TrimDateStart < TemporalOperator
-      register __FILE__
+      register __FILE__, :omopv4
 
       desc <<-EOF
 Trims the start_date of the LHS set of results by the RHS's latest

--- a/lib/conceptql/operators/union.rb
+++ b/lib/conceptql/operators/union.rb
@@ -3,7 +3,7 @@ require_relative 'pass_thru'
 module ConceptQL
   module Operators
     class Union < PassThru
-      register __FILE__
+      register __FILE__, :omopv4
 
       desc 'Pools sets of incoming results into a single large set of results.'
       allows_many_upstreams

--- a/lib/conceptql/operators/visit.rb
+++ b/lib/conceptql/operators/visit.rb
@@ -3,7 +3,7 @@ require_relative 'operator'
 module ConceptQL
   module Operators
     class Visit < Operator
-      register __FILE__
+      register __FILE__, :omopv4
 
       desc 'Generates all visit_occurrence records, or, if fed a stream, fetches all visit_occurrence records for the people represented in the incoming result set.'
       types :visit_occurrence

--- a/lib/conceptql/operators/visit_occurrence.rb
+++ b/lib/conceptql/operators/visit_occurrence.rb
@@ -3,7 +3,7 @@ require_relative 'casting_operator'
 module ConceptQL
   module Operators
     class VisitOccurrence < CastingOperator
-      register __FILE__
+      register __FILE__, :omopv4
 
       desc 'Returns all visits in the database, or if given a upstream, converts all results to the set of visit_occurrences related to those results.'
       allows_one_upstream


### PR DESCRIPTION
To use a different data model for a query, you just pass a
:data_model option to Query.new.  This will get passed down to the
Nodifier, which will use it to determine which hash to look in for
operators.

Registering operators now requires specifying the data models
in which to register as arguments.  To use the same operator in
multiple data models, just pass additional arguments.

This doesn't change any existing behavior.  The only currently
supported data model is :omopv4, which is the default for
Nodifier, and is the data model into which all current operators
register.

This removes registering abstract operators that shouldn't be
directly callable by ConceptQL statements, such as operator
superclasses.