### PR TITLE
Add ConceptQL::Database

### DIFF
--- a/lib/conceptql.rb
+++ b/lib/conceptql.rb
@@ -1,6 +1,7 @@
 require "conceptql/version"
 require "conceptql/logger"
 require "conceptql/query"
+require "conceptql/database"
 
 module ConceptQL
   # Your code goes here...

--- a/lib/conceptql/database.rb
+++ b/lib/conceptql/database.rb
@@ -1,0 +1,15 @@
+module ConceptQL
+  class Database
+    attr :db
+
+    def initialize(db, opts={})
+      @db = db
+      @opts = opts.dup
+      @opts[:data_model] ||= :omopv4
+    end
+
+    def query(statement, opts={})
+      Query.new(db, statement, @opts.merge(opts))
+    end
+  end
+end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -22,9 +22,11 @@ require 'minitest/autorun'
 
 require 'logger'
 
+CDB = ConceptQL::Database.new(DB)
+
 class Minitest::Spec
   def query(statement)
-    ConceptQL::Query.new(DB, statement)
+    CDB.query(statement)
   end
   
   def dataset(statement)


### PR DESCRIPTION
This makes it simpler to create queries for the same database,
without passing that database as an argument to every call to
Query.new.