### PR TITLE
Add more tests

### DIFF
--- a/lib/conceptql/knitter.rb
+++ b/lib/conceptql/knitter.rb
@@ -29,7 +29,7 @@ module ConceptQL
     end
 
     def diagram_dir
-      @diagram_dir ||= (file.dirname + file.basename('.md.cql')).tap { |d| d.rmtree if d.exist? ; d.mkpath }
+      @diagram_dir ||= (dir + file.basename('.md.cql')).tap { |d| d.rmtree if d.exist? ; d.mkpath }
     end
 
     def diagram_relative_path

--- a/lib/conceptql/operators/operator.rb
+++ b/lib/conceptql/operators/operator.rb
@@ -67,7 +67,6 @@ module ConceptQL
           .select_append{count{}.*.as(:rows)}
           .select_append{count(:person_id).distinct.as(:n)}
           .each do |h|
-            puts h
             annotation[h.delete(:criterion_type).to_sym] = h
         end
         types.each do |type|

--- a/test/fake_annotater_test.rb
+++ b/test/fake_annotater_test.rb
@@ -1,0 +1,31 @@
+require_relative 'helper'
+require 'conceptql/fake_annotater'
+
+describe ConceptQL::FakeAnnotater do
+  it "should work correctly for operators with single values" do
+    ConceptQL::FakeAnnotater.new([:icd9, '412']).annotate.must_equal [:icd9, "412", {:annotation=>{:condition_occurrence=>{}}}]
+  end
+
+  it "should work correctly for operators with multiple values" do
+    ConceptQL::FakeAnnotater.new([:icd9, '411', '412']).annotate.must_equal [:icd9, "411", "412", {:annotation=>{:condition_occurrence=>{}}}]
+  end
+
+  it "should work correctly for operators with hash arguments" do
+    ConceptQL::FakeAnnotater.new(
+      [:any_overlap,
+       {:left=>[:icd9, "412"],
+        :right=>[:date_range, {:start=>"2010-01-01", :end=>"2010-12-31"}]}]
+     ).annotate.must_equal([:any_overlap,
+       {:left=>[:icd9, "412", {:annotation=>{:condition_occurrence=>{}}}],
+        :right=>[:date_range, {:start=>"2010-01-01", :end=>"2010-12-31", :annotation=>{:date=>{}}}], :annotation=>{:condition_occurrence=>{}}}
+     ])
+  end
+
+  it "should work correctly for operators with upsreams" do
+    ConceptQL::FakeAnnotater.new([:union, [:icd9, "412"], [:cpt, "99214"]]).annotate.must_equal([:union,
+      [:icd9, "412", {:annotation=>{:condition_occurrence=>{}}}],
+      [:cpt, "99214", {:annotation=>{:procedure_occurrence=>{}}}],
+      {:annotation=>{:condition_occurrence=>{}, :procedure_occurrence=>{}}}
+    ])
+  end
+end

--- a/test/knitter/conceptql.md.cql
+++ b/test/knitter/conceptql.md.cql
@@ -1,0 +1,37 @@
+# ConceptQL Specification
+
+ConceptQL (pronounced concept-Q-L) is a high-level language that allows researchers to unambiguously define their research algorithms.
+
+## Motivation for ConceptQL
+
+Outcomes Insights intends to build a vast library of research algorithms and apply those algorithms to large databases of claims data.  Early into building the library, we realized we had to overcome two major issues:
+
+1. Methods sections of research papers commonly use natural language to specify the criteria used to build cohorts from a claims database.
+    - Algorithms defined in natural language are often imprecise, open to multiple interpretations, and generally difficult to reproduce.
+    - Researchers could benefit from a language that removes the ambiguity of natural language while increasing the reproducibility of their research algorithms.
+1. Querying against claims databases is often difficult.
+    - Hand-coding algorithms to extract cohorts from datasets is time-consuming, error-prone, and opaque.
+    - Researchers could benefit from a language that allows algorithms to be defined at a high-level and then gets translated into the appropriate queries against a database.
+
+We developed ConceptQL to address these two issues.
+
+We are writing a tool that can read research algorithms defined in ConceptQL.  The tool can create a diagram for the algorithm which makes it easy to visualize and understand.  The tool can also translate the algorithm into a SQL query which runs against data structured in [OMOP's Common Data Model (CDM)](http://omop.org/CDM).  The purpose of the CDM is to standardize the format and content of observational data, so standardized applications, tools and methods can be applied to them.
+
+For instance, using ConceptQL we can take a statement that looks like this:
+
+```YAML
+:icd9: '412'
+```
+
+And generate a diagram that looks like this:
+
+```ConceptQL
+[
+  "icd9",
+  "412"
+]
+```
+
+And generate SQL that looks like this:
+
+

--- a/test/knitter/conceptql.md.expect
+++ b/test/knitter/conceptql.md.expect
@@ -1,0 +1,53 @@
+# ConceptQL Specification
+
+ConceptQL (pronounced concept-Q-L) is a high-level language that allows researchers to unambiguously define their research algorithms.
+
+## Motivation for ConceptQL
+
+Outcomes Insights intends to build a vast library of research algorithms and apply those algorithms to large databases of claims data.  Early into building the library, we realized we had to overcome two major issues:
+
+1. Methods sections of research papers commonly use natural language to specify the criteria used to build cohorts from a claims database.
+    - Algorithms defined in natural language are often imprecise, open to multiple interpretations, and generally difficult to reproduce.
+    - Researchers could benefit from a language that removes the ambiguity of natural language while increasing the reproducibility of their research algorithms.
+1. Querying against claims databases is often difficult.
+    - Hand-coding algorithms to extract cohorts from datasets is time-consuming, error-prone, and opaque.
+    - Researchers could benefit from a language that allows algorithms to be defined at a high-level and then gets translated into the appropriate queries against a database.
+
+We developed ConceptQL to address these two issues.
+
+We are writing a tool that can read research algorithms defined in ConceptQL.  The tool can create a diagram for the algorithm which makes it easy to visualize and understand.  The tool can also translate the algorithm into a SQL query which runs against data structured in [OMOP's Common Data Model (CDM)](http://omop.org/CDM).  The purpose of the CDM is to standardize the format and content of observational data, so standardized applications, tools and methods can be applied to them.
+
+For instance, using ConceptQL we can take a statement that looks like this:
+
+```YAML
+:icd9: '412'
+```
+
+And generate a diagram that looks like this:
+
+
+```YAML
+---
+- icd9
+- '412'
+
+```
+
+![](conceptql/f6b4fc31703cfb6327bbbd4614af8bb72da6d39fa3d53ada63a70157f2fad80e.png)
+
+| person_id | criterion_id | criterion_type | start_date | end_date | source_value |
+| --------- | ------------ | -------------- | ---------- | -------- | ------------ |
+| 17 | 1712 | condition_occurrence | 2008-08-25 | 2008-08-25 | 412 |
+| 17 | 1829 | condition_occurrence | 2009-04-30 | 2009-04-30 | 412 |
+| 37 | 4359 | condition_occurrence | 2010-02-12 | 2010-02-12 | 412 |
+| 53 | 5751 | condition_occurrence | 2008-06-05 | 2008-06-05 | 412 |
+| 59 | 6083 | condition_occurrence | 2009-07-19 | 2009-07-22 | 412 |
+| 64 | 6902 | condition_occurrence | 2009-07-25 | 2009-07-25 | 412 |
+| 71 | 7865 | condition_occurrence | 2008-11-16 | 2008-11-16 | 412 |
+| 75 | 8397 | condition_occurrence | 2010-10-06 | 2010-10-06 | 412 |
+| 79 | 8618 | condition_occurrence | 2009-01-28 | 2009-01-30 | 412 |
+| 86 | 9882 | condition_occurrence | 2009-01-03 | 2009-01-09 | 412 |
+
+And generate SQL that looks like this:
+
+

--- a/test/knitter/fake.md.cql
+++ b/test/knitter/fake.md.cql
@@ -1,0 +1,10 @@
+And generate a diagram that looks like this:
+
+```ConceptQL
+[
+  "vsac",
+  "999"
+]
+```
+
+And generate SQL that looks like this:

--- a/test/knitter/fake.md.expect
+++ b/test/knitter/fake.md.expect
@@ -1,0 +1,15 @@
+And generate a diagram that looks like this:
+
+
+```YAML
+---
+- vsac
+- '999'
+
+```
+
+![](fake/b4c4be0eabd9bc7d878a4b8a77bbf2e172d579c9ed915729278cec58f6d4d9f0.png)
+
+```No Results.  Statement is experimental.```
+
+And generate SQL that looks like this:

--- a/test/knitter/no_conceptql.md.cql
+++ b/test/knitter/no_conceptql.md.cql
@@ -1,0 +1,36 @@
+# ConceptQL Specification
+
+ConceptQL (pronounced concept-Q-L) is a high-level language that allows researchers to unambiguously define their research algorithms.
+
+## Motivation for ConceptQL
+
+Outcomes Insights intends to build a vast library of research algorithms and apply those algorithms to large databases of claims data.  Early into building the library, we realized we had to overcome two major issues:
+
+1. Methods sections of research papers commonly use natural language to specify the criteria used to build cohorts from a claims database.
+    - Algorithms defined in natural language are often imprecise, open to multiple interpretations, and generally difficult to reproduce.
+    - Researchers could benefit from a language that removes the ambiguity of natural language while increasing the reproducibility of their research algorithms.
+1. Querying against claims databases is often difficult.
+    - Hand-coding algorithms to extract cohorts from datasets is time-consuming, error-prone, and opaque.
+    - Researchers could benefit from a language that allows algorithms to be defined at a high-level and then gets translated into the appropriate queries against a database.
+
+We developed ConceptQL to address these two issues.
+
+We are writing a tool that can read research algorithms defined in ConceptQL.  The tool can create a diagram for the algorithm which makes it easy to visualize and understand.  The tool can also translate the algorithm into a SQL query which runs against data structured in [OMOP's Common Data Model (CDM)](http://omop.org/CDM).  The purpose of the CDM is to standardize the format and content of observational data, so standardized applications, tools and methods can be applied to them.
+
+For instance, using ConceptQL we can take a statement that looks like this:
+
+```YAML
+:icd9: '412'
+```
+
+And generate a diagram that looks like this:
+
+```ConceptQ
+[
+  "icd9",
+  "412"
+]
+```
+
+And generate SQL that looks like this:
+

--- a/test/knitter/title.md.cql
+++ b/test/knitter/title.md.cql
@@ -1,0 +1,12 @@
+And generate a diagram that looks like this:
+
+```ConceptQL
+foo bar
+#
+[
+  "icd9",
+  "999"
+]
+```
+
+And generate SQL that looks like this:

--- a/test/knitter/title.md.expect
+++ b/test/knitter/title.md.expect
@@ -1,0 +1,16 @@
+And generate a diagram that looks like this:
+
+foo bar
+
+```YAML
+---
+- icd9
+- '999'
+
+```
+
+![foo bar](title/2b0dbefc0c25a7c5047159f06e1027e38d7a1d5ab7c1ee701439cb13f95e7707.png)
+
+```No Results found.```
+
+And generate SQL that looks like this:

--- a/test/knitter_test.rb
+++ b/test/knitter_test.rb
@@ -1,0 +1,47 @@
+require_relative 'helper'
+require 'conceptql/knitter'
+
+describe ConceptQL::Knitter do
+  after do
+    (Dir['test/knitter/.[0-9a-f]*/*'] + Dir['test/knitter/*.md'] + Dir['test/knitter/*/*.png']).each{|f| File.delete(f)}
+    (Dir['test/knitter/*'] + Dir['test/knitter/.[0-9a-f]*']).each{|f| Dir.rmdir(f) if File.directory?(f) && Dir.new(f).entries == ['.', '..']}
+  end
+
+  def knit(example)
+    ConceptQL::Knitter.new(CDB, "test/knitter/#{example}.md.cql").knit
+    File.read("test/knitter/#{example}.md")
+  end
+
+  def silence
+    ConceptQL::Knitter::ConceptQLChunk.send(:define_method, :puts){|*|}
+    yield
+  ensure
+    ConceptQL::Knitter::ConceptQLChunk.send(:undef_method, :puts) 
+  end
+
+  it "returns values without ```ConceptQL as is" do
+    knit('empty').must_equal ''
+    knit('no_conceptql').must_equal File.read("test/knitter/no_conceptql.md.cql")
+  end
+
+  it "replaces ```ConceptQL with diagrams" do
+    # Also test cache
+    2.times do
+      knit('conceptql').must_equal File.read("test/knitter/conceptql.md.expect")
+    end
+  end
+
+  it "handles titles and no results" do
+    2.times do
+      knit('title').must_equal File.read("test/knitter/title.md.expect")
+    end
+  end
+
+  it "handles bad statements using fake annotater" do
+    silence do
+      2.times do
+        knit('fake').must_equal File.read("test/knitter/fake.md.expect")
+      end
+    end
+  end
+end

--- a/test/operators/date_range_test.rb
+++ b/test/operators/date_range_test.rb
@@ -10,4 +10,10 @@ describe ConceptQL::Operators::DateRange do
       [:date_range, {:start=>"START", :end=>"END"}]
     ).must_equal("person"=>250)
   end
+
+  it "#annotate should work correctly" do
+    query(
+      [:date_range, {:start=>"2008-03-13", :end=>"2008-03-20"}]
+    ).annotate.must_equal(["date_range", {:start=>"2008-03-13", :end=>"2008-03-20", :annotation=>{:person=>{:rows=>250, :n=>250}}}])
+  end
 end

--- a/test/operators/except_test.rb
+++ b/test/operators/except_test.rb
@@ -17,4 +17,15 @@ describe ConceptQL::Operators::Except do
         :right=>[:union, [:condition_type, :inpatient_header], [:race, "White"]]}]
     ).must_equal("condition_occurrence"=>42, "procedure_occurrence"=>1221, "person"=>22)
   end
+
+  it "annotate should work correctly" do
+    query(
+      [:except,
+       {:left=>[:icd9, "412"], :right=>[:condition_type, :inpatient_header]}]
+    ).annotate.must_equal(["except",
+      {:left=>["icd9", "412", {:annotation=>{:condition_occurrence=>{:rows=>50, :n=>38}}, :name=>"ICD-9 CM"}],
+       :right=>["condition_type", :inpatient_header, {:annotation=>{:condition_occurrence=>{:rows=>1372, :n=>92}}}],
+       :annotation=>{:condition_occurrence=>{:rows=>42, :n=>33}}}
+    ])
+  end
 end

--- a/test/operators/intersect_test.rb
+++ b/test/operators/intersect_test.rb
@@ -18,4 +18,14 @@ describe ConceptQL::Operators::Intersect do
        [:race, "White"]]
     ).must_equal("person"=>[1, 2, 5, 7, 8, 12, 14, 20, 23, 25, 27, 28, 38, 40, 45, 51, 53, 55, 59, 60, 63, 65, 68, 78, 80, 82, 85, 90, 91, 92, 95, 96, 99, 101, 107, 108, 110, 112, 119, 120, 125, 127, 128, 130, 131, 132, 138, 142, 143, 145, 146, 149, 150, 152, 153, 154, 158, 161, 164, 172, 174, 175, 178, 181, 183, 187, 189, 191, 192, 195, 203, 205, 206, 207, 212, 215, 218, 222, 227, 229, 231, 233, 238, 239, 244, 245, 246, 249, 251, 262, 266, 268, 270, 271, 273, 274, 275, 276, 279, 280, 285, 287, 288, 289], "condition_occurrence"=>[6083, 8618, 9882, 15149, 18412, 20005, 26766, 31877])
   end
+
+  it "#annotate should work correctly" do
+    query(
+      [:intersect, [:icd9, "412"], [:condition_type, :inpatient_header]]
+    ).annotate.must_equal(["intersect",
+      ["icd9", "412", {:annotation=>{:condition_occurrence=>{:rows=>50, :n=>38}}, :name=>"ICD-9 CM"}],
+      ["condition_type", :inpatient_header, {:annotation=>{:condition_occurrence=>{:rows=>1372, :n=>92}}}],
+      {:annotation=>{:condition_occurrence=>{:rows=>8, :n=>8}}}
+    ])
+  end
 end


### PR DESCRIPTION
This adds tests for FakeAnnotate and Knitter, as well as more tests for Query#annotate to make sure it works with additional operators, such as operators with options and binary operators.

Both FakeAnnotate and Knitter have tests with 100% line coverage, except for 2 methods in Knitter which are not called and could possibly be removed

A couple minor lib changes are included. One removes a debugging line left in, and the other uses Knitter#lib inside Knitter.