### PR TITLE
Avoid symlink attack in bin/conceptql metadata

### DIFF
--- a/lib/conceptql/cli.rb
+++ b/lib/conceptql/cli.rb
@@ -75,7 +75,7 @@ module ConceptQL
 
     desc 'metadata', 'Generates the metadata.js file for the JAM'
     def metadata
-      File.write('/tmp/metadata.js', "var metadata = #{ConceptQL::Nodifier.new.to_metadata.to_json};")
+      File.write('metadata.js', "var metadata = #{ConceptQL::Nodifier.new.to_metadata.to_json};")
     end
 
     desc 'convert', 'Converts from hash-based syntax to list-based syntax'


### PR DESCRIPTION
It's not safe to write to any file in a known world-writable
location, as an attacker can symlink it to any other file that
you can write to.

One secure way to write to a file in /tmp is to use a mkstemp
or similar function, but I think a simpler solution here is just
to write the file to current directory.  If that isn't advisable,
then metadata should require a file name argument for where
to write the file.