### PR TITLE
Fix queries to get the columns on Impala in the Intersect operator

### DIFF
--- a/lib/conceptql/operators/intersect.rb
+++ b/lib/conceptql/operators/intersect.rb
@@ -26,6 +26,10 @@ module ConceptQL
         end
         typed_queries = exprs.map do |type, queries|
           queries.inject do |q, query|
+            # Set columns so that impala's INTERSECT emulation doesn't use a query to determine them
+            q.instance_variable_set(:@columns, SELECTED_COLUMNS)
+            query.instance_variable_set(:@columns, SELECTED_COLUMNS)
+
             q.intersect(query)
           end
         end


### PR DESCRIPTION
This is a similar to the change made to the Except operator.