### PR TITLE
Check that all recall operators in the scope are valid before executing query

### DIFF
--- a/lib/conceptql/operators/operator.rb
+++ b/lib/conceptql/operators/operator.rb
@@ -157,7 +157,7 @@ module ConceptQL
         end
         res = [self.class.just_class_name.underscore, *annotate_values(db)] 
 
-        if upstreams_valid?(db)
+        if upstreams_valid?(db) && scope.valid?
           scope.with_ctes(evaluate(db), db)
             .from_self
             .select_group(:criterion_type)

--- a/lib/conceptql/scope.rb
+++ b/lib/conceptql/scope.rb
@@ -127,7 +127,17 @@ module ConceptQL
       sort_ctes(sorted, unsorted, new_deps)
     end
 
+    def valid?
+      recall_dependencies.each_value do |deps|
+        unless (deps - known_operators.keys).empty?
+          return false
+        end
+      end
+      true
+    end
+
     def with_ctes(query, db)
+      raise "recall operator use without matching label" unless valid?
       ctes = sort_ctes([], known_operators, recall_dependencies)
 
       ctes.each do |label, operator|


### PR DESCRIPTION
Fixes an infinite loop in sort_ctes if an invalid recall operator
is used (one with no matching label).

When annotating, skip all annotations if the scope is not valid,
as otherwise it will attempt to execute invalid SQL.