### PR TITLE
Handle operators that use extra_ctes that have recall labels

### DIFF
--- a/lib/conceptql/operators/occurrence.rb
+++ b/lib/conceptql/operators/occurrence.rb
@@ -47,6 +47,7 @@ occurrence, this operator returns nothing for that person.
       allows_one_upstream
       validate_at_least_one_upstream
       option :unique, type: :boolean, label: 'Unique Source Values Only'
+      uses_extra_ctes
 
       def query_cols
         SELECTED_COLUMNS + [:rn]

--- a/lib/conceptql/operators/one_in_two_out.rb
+++ b/lib/conceptql/operators/one_in_two_out.rb
@@ -28,6 +28,7 @@ twice in an outpatient setting with a 30-day gap.
       validate_option DateAdjuster::VALID_INPUT, :outpatient_minimum_gap, :outpatient_maximum_gap
 
       default_query_columns
+      uses_extra_ctes
 
       def query(db)
         db.extension :date_arithmetic

--- a/test/operators/recall_test.rb
+++ b/test/operators/recall_test.rb
@@ -1,7 +1,7 @@
 require_relative '../helper'
 
 describe ConceptQL::Operators::Recall do
-  it "should raise error if attmping executing invalid recall" do
+  it "should raise error if attempting to execute invalid recall" do
     proc do
       criteria_ids(
       ["after",
@@ -20,6 +20,15 @@ describe ConceptQL::Operators::Recall do
   end
 
   it "should produce correct results" do
+    criteria_ids(
+      [:union,
+        [:recall, 'label1'],
+        [:one_in_two_out,
+         [:icd9, '412'],
+         label: 'label1']
+      ]
+    ).must_equal("condition_occurrence"=>[1829, 6083, 8618, 9882, 15149, 17774, 18412, 20005, 21619, 24437, 24707, 25309, 25888, 26766, 28188, 31542, 31877])
+
     criteria_ids(
       [:union,
        ["icd9", "412", {"label": "Heart Attack"}],


### PR DESCRIPTION
If an operator uses extra_ctes and is a recall label, it needs to
be added as a CTE before uses of the recall operator.

Currently, only the one_in_two_out operator and the occurrence
operator use extra ctes, so this just adds a notation in both
classes.