### PR TITLE
Implement TemporalOperator :within option

### DIFF
--- a/lib/conceptql/date_adjuster.rb
+++ b/lib/conceptql/date_adjuster.rb
@@ -17,11 +17,12 @@ module ConceptQL
       @adjustments ||= parse(str)
     end
 
-    def adjust(column)
+    def adjust(column, reverse=false)
       return Sequel.expr(:end_date) if str.downcase == 'end'
       return Sequel.expr(:start_date) if str.downcase == 'start'
       return Sequel.cast(Date.parse(str).strftime('%Y-%m-%d'), Date) if str =~ /^\d{4}-\d{2}-\d{2}$/
       adjusted_date = adjustments.inject(Sequel.expr(column)) do |sql, (units, quantity)|
+        quantity *= -1 if reverse
         if quantity > 0
           manipulator.date_add(sql, units => quantity)
         else

--- a/lib/conceptql/operators/after.rb
+++ b/lib/conceptql/operators/after.rb
@@ -21,6 +21,10 @@ R-----R
         right.evaluate(db).from_self.group_by(:person_id).select(:person_id, Sequel.function(:min, :end_date).as(:end_date)).as(:r)
       end
 
+      def occurrences_column
+        :r__end_date
+      end
+
       def where_clause
         Proc.new { l__start_date > r__end_date }
       end

--- a/lib/conceptql/operators/after.rb
+++ b/lib/conceptql/operators/after.rb
@@ -14,6 +14,9 @@ R-----R
    R-----R
         L-----Y----L
       EOF
+
+      within_skip :after
+
       def right_stream(db)
         right.evaluate(db).from_self.group_by(:person_id).select(:person_id, Sequel.function(:min, :end_date).as(:end_date)).as(:r)
       end

--- a/lib/conceptql/operators/before.rb
+++ b/lib/conceptql/operators/before.rb
@@ -11,8 +11,14 @@ Any result in the LHR with an end_date that occurs before the most recent start_
 All other results are discarded, including all results in the RHR.
       EOF
 
+      within_skip :before
+
       def right_stream(db)
         right.evaluate(db).from_self.group_by(:person_id).select(:person_id, Sequel.function(:max, :start_date).as(:start_date)).as(:r)
+      end
+
+      def within_column
+        :l__end_date
       end
 
       def where_clause

--- a/lib/conceptql/operators/concurrent_within.rb
+++ b/lib/conceptql/operators/concurrent_within.rb
@@ -1,0 +1,57 @@
+require_relative 'operator'
+require_relative '../date_adjuster'
+
+module ConceptQL
+  module Operators
+    class ConcurrentWithin < Operator
+      register __FILE__, :omopv4
+
+      desc 'Filters each upstream to only include rows where there are matching entries in each of the other upstreams.'
+      option :start, type: :string
+      option :end, type: :string
+      validate_at_least_one_upstream
+      validate_no_arguments
+      validate_option DateAdjuster::VALID_INPUT, :start, :end
+      category "Modify Data"
+      basic_type :temporal
+      default_query_columns
+
+      def query(db)
+        db.extension :date_arithmetic
+        datasets = upstreams.map do |stream|
+          stream.evaluate(db)
+        end 
+
+        return datasets.first.from_self if datasets.length == 1
+
+        adjusted_start_date = DateAdjuster.new(options[:start]).adjust(:l__start_date, true)
+        adjusted_end_date = DateAdjuster.new(options[:end]).adjust(:l__end_date)
+
+        datasets = datasets.map do |ds|
+          matching = ds.from_self(:alias=>:l)
+
+          (datasets - [ds]).each do |other|
+            other = other
+              .from_self(:alias=>:r)
+              .where(adjusted_start_date <= :r__start_date)
+              .where(adjusted_end_date >= :r__end_date)
+              .select(:person_id)
+
+            matching = matching.where(:person_id=>other)
+          end
+
+          matching
+        end
+
+        ds, *rest = datasets
+        rest.each do |other|
+          ds = ds.union(other, :from_self=>nil)
+        end
+
+        ds.from_self
+      end
+    end
+  end
+end
+
+

--- a/lib/conceptql/operators/operator.rb
+++ b/lib/conceptql/operators/operator.rb
@@ -521,7 +521,7 @@ module ConceptQL
       end
 
       def validate_no_arguments
-        add_error("has arguments", @arguments.inspect) unless @arguments.empty?
+        add_error("has arguments", @arguments) unless @arguments.empty?
       end
 
       def validate_one_argument

--- a/lib/conceptql/operators/operator.rb
+++ b/lib/conceptql/operators/operator.rb
@@ -530,7 +530,7 @@ module ConceptQL
       end
 
       def validate_at_most_one_argument
-        add_error("has multiple arguments") if @arguments.length > 1
+        add_error("has multiple arguments", @arguments) if @arguments.length > 1
       end
 
       def validate_at_least_one_argument

--- a/lib/conceptql/operators/temporal_operator.rb
+++ b/lib/conceptql/operators/temporal_operator.rb
@@ -17,7 +17,7 @@ module ConceptQL
       option :occurrences, type: :integer, desc: "Number of occurrences that must precede the event of interest, e.g. if you'd like the 4th event in a set of events, set occurrences to 3"
 
       validate_option DateAdjuster::VALID_INPUT, :within, :at_least
-      validate_option /\A\d+\Z/, :occurrences
+      validate_option /\A\d+\z/, :occurrences
 
       def self.within_skip(type)
         define_method(:"within_check_#{type}?"){false}

--- a/lib/conceptql/operators/temporal_operator.rb
+++ b/lib/conceptql/operators/temporal_operator.rb
@@ -29,25 +29,46 @@ module ConceptQL
                .where(where_clause)
                .select_all(:l)
 
-        ds = add_within_condition(ds)
+        ds = add_option_conditions(ds)
         ds.from_self
       end
 
-      def add_within_condition(ds)
+      def add_option_conditions(ds)
         if within = options[:within]
-          within = DateAdjuster.new(within)
-          after = within.adjust(:r__start_date, true)
-          before = within.adjust(:r__end_date)
-          within_col = Sequel.expr(within_column)
-          ds = ds.where{within_col >= after} if within_check_after?
-          ds = ds.where{within_col <= before} if within_check_before?
+          ds = add_within_condition(ds, within)
+        end
+
+        if occurrences = options[:occurrences]
+          ds = add_occurrences_condition(ds, occurrences)
         end
 
         ds
       end
 
+      def add_within_condition(ds, within)
+        within = DateAdjuster.new(within)
+        after = within.adjust(:r__start_date, true)
+        before = within.adjust(:r__end_date)
+        within_col = Sequel.expr(within_column)
+        ds = ds.where{within_col >= after} if within_check_after?
+        ds = ds.where{within_col <= before} if within_check_before?
+        ds
+      end
+
+      def add_occurrences_condition(ds, occurrences)
+        occurrences_col = occurrences_column
+        ds.select_append{row_number{}.over(:partition => :r__person_id, :order => occurrences_col).as(:occurrence)}
+          .from_self
+          .select(*query_columns(ds))
+          .where{occurrence > occurrences}
+      end
+
       def within_column
         :l__start_date
+      end
+
+      def occurrences_column
+        :r__start_date
       end
 
       def within_check_after?

--- a/lib/conceptql/operators/time_window.rb
+++ b/lib/conceptql/operators/time_window.rb
@@ -52,8 +52,6 @@ module ConceptQL
         adjusted_date(:end, :end_date)
       end
 
-      # NOTE: This produces PostgreSQL-specific date adjustment.  I'm not yet certain how to generalize this
-      # or make different versions based on RDBMS
       def adjusted_date(option_arg, column)
         adjusted_date = DateAdjuster.new(options[option_arg], manipulator: options[:manipulator]).adjust(column)
         adjusted_date.as(column)

--- a/lib/conceptql/operators/trim_date_end.rb
+++ b/lib/conceptql/operators/trim_date_end.rb
@@ -45,7 +45,7 @@ is passed through unaffected.
                   .select(*new_columns)
                   .select_append(Sequel.as(Sequel.function(:least, :l__end_date, :r__start_date), :end_date))
 
-        ds = add_within_condition(ds)
+        ds = add_option_conditions(ds)
         ds.from_self
       end
 

--- a/lib/conceptql/operators/trim_date_end.rb
+++ b/lib/conceptql/operators/trim_date_end.rb
@@ -28,6 +28,7 @@ If the start_date of the result in the RHR is later than the end_date of the res
 is passed through unaffected.
       EOF
       allows_one_upstream
+      within_skip :before
 
       def query(db)
         grouped_right = db.from(right_stream(db)).select_group(:person_id).select_append(Sequel.as(Sequel.function(:min, :start_date), :start_date))
@@ -38,12 +39,18 @@ is passed through unaffected.
         # If the RHS's min start date is less than the LHS start date,
         # the entire LHS date range is truncated, which implies the row itself
         # is ineligible to pass thru
-        db.from(db.from(left_stream(db))
+        ds = db.from(left_stream(db))
                   .left_join(Sequel.as(grouped_right, :r), l__person_id: :r__person_id)
                   .where(where_criteria)
                   .select(*new_columns)
                   .select_append(Sequel.as(Sequel.function(:least, :l__end_date, :r__start_date), :end_date))
-               )
+
+        ds = add_within_condition(ds)
+        ds.from_self
+      end
+
+      def within_column
+        :l__end_date
       end
 
       private

--- a/lib/conceptql/operators/trim_date_start.rb
+++ b/lib/conceptql/operators/trim_date_start.rb
@@ -46,11 +46,16 @@ is passed through unaffected.
                   .select(*new_columns)
                   .select_append(Sequel.as(Sequel.function(:greatest, :l__start_date, :r__end_date), :start_date))
 
-        ds = add_within_condition(ds)
+        ds = add_option_conditions(ds)
         ds.from_self
       end
 
       private
+
+      def occurrences_column
+        :r__end_date
+      end
+
       def new_columns
         (COLUMNS - [:start_date]).map { |col| "l__#{col}".to_sym }
       end

--- a/lib/conceptql/operators/trim_date_start.rb
+++ b/lib/conceptql/operators/trim_date_start.rb
@@ -29,6 +29,7 @@ is passed through unaffected.
       EOF
 
       allows_one_upstream
+      within_skip :after
 
       def query(db)
         grouped_right = db.from(right_stream(db)).select_group(:person_id).select_append(Sequel.as(Sequel.function(:max, :end_date), :end_date))
@@ -39,12 +40,14 @@ is passed through unaffected.
         # If the RHS's min start date is less than the LHS start date,
         # the entire LHS date range is truncated, which implies the row itself
         # is ineligible to pass thru
-        db.from(db.from(left_stream(db))
+        ds = db.from(left_stream(db))
                   .join(Sequel.as(grouped_right, :r), l__person_id: :r__person_id)
                   .where(where_criteria)
                   .select(*new_columns)
                   .select_append(Sequel.as(Sequel.function(:greatest, :l__start_date, :r__end_date), :start_date))
-               )
+
+        ds = add_within_condition(ds)
+        ds.from_self
       end
 
       private

--- a/test/db.rb
+++ b/test/db.rb
@@ -1,6 +1,7 @@
 require 'sequelizer'
 
 DB = Object.new.extend(Sequelizer).db unless defined?(DB)
+DB.extension :date_arithmetic
 
 unless DB.table_exists?(:source_to_concept_map)
   $stderr.puts <<END

--- a/test/operators/after_test.rb
+++ b/test/operators/after_test.rb
@@ -65,7 +65,7 @@ describe ConceptQL::Operators::After do
                  ["gender", "Male",{:annotation=>{:counts=>{:person=>{:rows=>126, :n=>126}}}}],
                  {:annotation=>{:counts=>{:person=>{:rows=>126, :n=>126}}}, :start=>"50y", :end=>"50y"}]},
        1,
-       { :annotation=>{:counts=>{:condition_occurrence=>{:n=>0, :rows=>0}}, :errors=>[["has arguments"]]}}]
+       { :annotation=>{:counts=>{:condition_occurrence=>{:n=>0, :rows=>0}}, :errors=>[["has arguments", [1]]]}}]
     )
 
     # Check that within, at_least, and occurrences are checked

--- a/test/operators/after_test.rb
+++ b/test/operators/after_test.rb
@@ -9,6 +9,15 @@ describe ConceptQL::Operators::After do
     ).must_equal("condition_occurrence"=>[5751, 6083, 10865, 13741, 15149, 17041, 17772, 17774, 18412, 21619, 21627, 22933, 24437, 24471, 24707, 24721, 25309, 25417, 25875, 25888, 26766, 28177, 28188, 30831, 31877, 32104, 32463, 32981])
   end
 
+  it "should produce correct results when using :within option" do
+    criteria_ids(
+      [:after,
+       {:left=>[:icd9, "412"],
+        :right=>[:time_window, [:gender, "Male"], {:start=>"50y", :end=>"50y"}],
+        :within=>"3000d"}]
+    ).must_equal("condition_occurrence"=>[32104, 32981])
+  end
+
   it "should handle upstream errors when annotating" do
     query(
       [:after,

--- a/test/operators/after_test.rb
+++ b/test/operators/after_test.rb
@@ -18,6 +18,15 @@ describe ConceptQL::Operators::After do
     ).must_equal("condition_occurrence"=>[32104, 32981])
   end
 
+  it "should produce correct results when using :occurrences option" do
+    criteria_ids(
+      [:after,
+       {:left=>[:icd9, "412"],
+        :right=>[:time_window, [:gender, "Male"], {:start=>"50y", :end=>"50y"}],
+        :occurrences=>1}]
+    ).must_equal("condition_occurrence"=>[17772, 21627, 24471, 24721, 25309, 25888, 28177, 32104])
+  end
+
   it "should handle upstream errors when annotating" do
     query(
       [:after,

--- a/test/operators/any_overlap_test.rb
+++ b/test/operators/any_overlap_test.rb
@@ -14,4 +14,13 @@ describe ConceptQL::Operators::AnyOverlap do
         :right=>[:icd9, "412"]}]
     ).must_equal("person"=>[37, 75, 88, 108, 149, 183, 206, 209, 231, 255, 260])
   end
+
+  it "should produce correct results when using :within option" do
+    criteria_ids(
+      [:any_overlap,
+       {:left=>[:icd9, "412"],
+        :right=>[:date_range, {:start=>"2010-01-01", :end=>"2010-12-31"}],
+        :within=>'-100d'}]
+    ).must_equal("condition_occurrence"=>[10443, 13741, 24989, 31877])
+  end
 end

--- a/test/operators/any_overlap_test.rb
+++ b/test/operators/any_overlap_test.rb
@@ -23,4 +23,20 @@ describe ConceptQL::Operators::AnyOverlap do
         :within=>'-100d'}]
     ).must_equal("condition_occurrence"=>[10443, 13741, 24989, 31877])
   end
+
+  it "should produce correct results when using :occurrences option" do
+    criteria_ids(
+      [:any_overlap,
+       {:left=>[:icd9, "412"],
+        :right=>[:date_range, {:start=>"2010-01-01", :end=>"2010-12-31"}],
+        :occurrences=>1}]
+    ).must_equal({})
+
+    criteria_ids(
+      [:any_overlap,
+       {:left=>[:icd9, "412"],
+        :right=>[:date_range, {:start=>"2010-01-01", :end=>"2010-12-31"}],
+        :occurrences=>0}]
+    ).must_equal("condition_occurrence"=>[4359, 8397, 10443, 13741, 17774, 21619, 24437, 24989, 28188, 31542, 31877])
+  end
 end

--- a/test/operators/before_test.rb
+++ b/test/operators/before_test.rb
@@ -10,6 +10,10 @@ describe ConceptQL::Operators::Before do
       [:before, {:left=>[:icd9, "412"], :right=>[:first, [:icd9, "401.9"]]}]
     ).must_equal("condition_occurrence"=>[5751, 21006, 24721])
   end
+
+  it "should produce correct results when using :within option" do
+    criteria_ids(
+      [:before, {:left=>[:icd9, "412"], :right=>[:icd9, "401.9"], :within=>'30d'}]
+    ).must_equal("condition_occurrence"=>[13741, 17774, 31542])
+  end
 end
-
-

--- a/test/operators/before_test.rb
+++ b/test/operators/before_test.rb
@@ -16,4 +16,10 @@ describe ConceptQL::Operators::Before do
       [:before, {:left=>[:icd9, "412"], :right=>[:icd9, "401.9"], :within=>'30d'}]
     ).must_equal("condition_occurrence"=>[13741, 17774, 31542])
   end
+
+  it "should produce correct results when using :occurrences option" do
+    criteria_ids(
+      [:before, {:left=>[:icd9, "412"], :right=>[:icd9, "401.9"], :occurrences=>1}]
+    ).must_equal("condition_occurrence"=>[1829, 17774, 20037, 24471, 24721, 25417, 25888, 28188, 31542])
+  end
 end

--- a/test/operators/complement_test.rb
+++ b/test/operators/complement_test.rb
@@ -61,7 +61,7 @@ describe ConceptQL::Operators::Complement do
       ["complement",
        ["icd9", "412", {:annotation=>{:counts=>{:condition_occurrence=>{:rows=>50, :n=>38}}}, :name=>"ICD-9 CM"}],
        ["icd9", "412", {:annotation=>{:counts=>{:condition_occurrence=>{:rows=>50, :n=>38}}}, :name=>"ICD-9 CM"}],
-       {:annotation=>{:counts=>{:condition_occurrence=>{:rows=>0, :n=>0}}, :errors=>[["has multiple upstreams"]]}}]
+       {:annotation=>{:counts=>{:condition_occurrence=>{:rows=>0, :n=>0}}, :errors=>[["has multiple upstreams", ["icd9", "icd9"]]]}}]
     )
 
     query(
@@ -70,7 +70,7 @@ describe ConceptQL::Operators::Complement do
       ["complement",
        ["icd9", "412", {:annotation=>{:counts=>{:condition_occurrence=>{:rows=>50, :n=>38}}}, :name=>"ICD-9 CM"}],
        "412",
-       {:annotation=>{:counts=>{:condition_occurrence=>{:rows=>0, :n=>0}}, :errors=>[["has arguments"]]}}]
+       {:annotation=>{:counts=>{:condition_occurrence=>{:rows=>0, :n=>0}}, :errors=>[["has arguments", ["412"]]]}}]
     )
   end
 end

--- a/test/operators/concurrent_within_test.rb
+++ b/test/operators/concurrent_within_test.rb
@@ -1,0 +1,17 @@
+require_relative '../helper'
+
+describe ConceptQL::Operators::ConcurrentWithin do
+  it "should produce correct results" do
+    criteria_ids(
+      [:concurrent_within, [:icd9, "412"], {:start=>"-2y", :end=>"-2y"}]
+    ).must_equal("condition_occurrence"=>[1712, 1829, 4359, 5751, 6083, 6902, 7865, 8397, 8618, 9882, 10196, 10443, 10865, 13016, 13741, 15149, 17041, 17772, 17774, 18412, 18555, 19736, 20005, 20037, 21006, 21619, 21627, 22875, 22933, 24437, 24471, 24707, 24721, 24989, 25309, 25417, 25875, 25888, 26766, 27388, 28177, 28188, 30831, 31387, 31542, 31792, 31877, 32104, 32463, 32981])
+
+    criteria_ids(
+      [:concurrent_within, [:icd9, "412"], [:place_of_service_code, "21"], {:start=>"1d", :end=>"1d"}]
+    ).must_equal({"visit_occurrence"=>[2705, 3847, 4378, 6640, 6642, 8108, 8806, 11783, 13972], "condition_occurrence"=>[6083, 8618, 9882, 15149, 18412, 20005, 26766, 31877]})
+
+    criteria_ids(
+      [:concurrent_within, [:icd9, "412"], [:place_of_service_code, "21"], {:start=>"-1d", :end=>"0d"}]
+    ).must_equal({"visit_occurrence"=>[6642]})
+  end
+end

--- a/test/operators/condition_type_test.rb
+++ b/test/operators/condition_type_test.rb
@@ -89,7 +89,7 @@ describe ConceptQL::Operators::ConditionType do
     ).annotate.must_equal(
       ["condition_type",
        ["icd9", "412", {:annotation=>{:counts=>{:condition_occurrence=>{:rows=>50, :n=>38}}}, :name=>"ICD-9 CM"}],
-       {:annotation=>{:counts=>{:condition_occurrence=>{:rows=>0, :n=>0}}, :errors=>[["has upstreams"], ["has no arguments"]]}}]
+       {:annotation=>{:counts=>{:condition_occurrence=>{:rows=>0, :n=>0}}, :errors=>[["has upstreams", ["icd9"]], ["has no arguments"]]}}]
     )
   end
 end

--- a/test/operators/count_test.rb
+++ b/test/operators/count_test.rb
@@ -25,7 +25,7 @@ describe ConceptQL::Operators::Count do
     query(
       [:count, 1]
     ).annotate.must_equal(
-      ["count", 1, {:annotation=>{:counts=>{:invalid=>{:rows=>0, :n=>0}}, :errors=>[["has no upstream"], ["has arguments"]]}}]
+      ["count", 1, {:annotation=>{:counts=>{:invalid=>{:rows=>0, :n=>0}}, :errors=>[["has no upstream"], ["has arguments", [1]]]}}]
     )
 
     query(
@@ -34,7 +34,7 @@ describe ConceptQL::Operators::Count do
       ["count",
        ["icd9", "412", {:annotation=>{:counts=>{:condition_occurrence=>{:rows=>50, :n=>38}}}, :name=>"ICD-9 CM"}],
        ["icd9", "401.9", {:annotation=>{:counts=>{:condition_occurrence=>{:rows=>1125, :n=>213}}}, :name=>"ICD-9 CM"}],
-       {:annotation=>{:counts=>{:condition_occurrence=>{:rows=>0, :n=>0}}, :errors=>[["has multiple upstreams"]]}}]
+       {:annotation=>{:counts=>{:condition_occurrence=>{:rows=>0, :n=>0}}, :errors=>[["has multiple upstreams", ["icd9", "icd9"]]]}}]
     )
   end
 end

--- a/test/operators/cpt_test.rb
+++ b/test/operators/cpt_test.rb
@@ -17,7 +17,7 @@ describe ConceptQL::Operators::Cpt do
     ).annotate.must_equal(
       ["cpt",
        ["icd9", "412", {:annotation=>{:counts=>{:condition_occurrence=>{:rows=>50, :n=>38}}}, :name=>"ICD-9 CM"}],
-       {:annotation=>{:counts=>{:condition_occurrence=>{:n=>0, :rows=>0}}, :errors=>[["has upstreams"], ["has no arguments"]]}, :name=>"CPT"}]
+       {:annotation=>{:counts=>{:condition_occurrence=>{:n=>0, :rows=>0}}, :errors=>[["has upstreams", ["icd9"]], ["has no arguments"]]}, :name=>"CPT"}]
     )
 
     query(

--- a/test/operators/date_range_test.rb
+++ b/test/operators/date_range_test.rb
@@ -25,7 +25,7 @@ describe ConceptQL::Operators::DateRange do
       ["date_range",
        ["icd9", "412", {:annotation=>{:counts=>{:condition_occurrence=>{:rows=>50, :n=>38}}}, :name=>"ICD-9 CM"}],
        {:start=>"START", :end=>"END",
-        :annotation=>{:counts=>{:person=>{:rows=>0, :n=>0}}, :errors=>[["has upstreams"]]}}]
+        :annotation=>{:counts=>{:person=>{:rows=>0, :n=>0}}, :errors=>[["has upstreams", ["icd9"]]]}}]
     )
 
     query(
@@ -34,7 +34,7 @@ describe ConceptQL::Operators::DateRange do
       ["date_range",
        "412",
        {:start=>"START", :end=>"END",
-        :annotation=>{:counts=>{:person=>{:rows=>0, :n=>0}}, :errors=>[["has arguments"]]}}]
+        :annotation=>{:counts=>{:person=>{:rows=>0, :n=>0}}, :errors=>[["has arguments", ["412"]]]}}]
     )
 
     query(

--- a/test/operators/death_test.rb
+++ b/test/operators/death_test.rb
@@ -18,7 +18,7 @@ describe ConceptQL::Operators::Death do
       ["death",
        ["person", {:annotation=>{:counts=>{:person=>{:rows=>250, :n=>250}}}}],
        ["icd9", "412", {:annotation=>{:counts=>{:condition_occurrence=>{:rows=>50, :n=>38}}}, :name=>"ICD-9 CM"}],
-       {:annotation=>{:counts=>{:death=>{:n=>0, :rows=>0}}, :errors=>[["has multiple upstreams"]]}}]
+       {:annotation=>{:counts=>{:death=>{:n=>0, :rows=>0}}, :errors=>[["has multiple upstreams", ["person", "icd9"]]]}}]
     )
 
     query(
@@ -26,7 +26,7 @@ describe ConceptQL::Operators::Death do
     ).annotate.must_equal(
       ["death",
        "412",
-       {:annotation=>{:counts=>{:death=>{:n=>0, :rows=>0}}, :errors=>[["has arguments"]]}}]
+       {:annotation=>{:counts=>{:death=>{:n=>0, :rows=>0}}, :errors=>[["has arguments", ["412"]]]}}]
     )
   end
 end

--- a/test/operators/drug_type_concept_test.rb
+++ b/test/operators/drug_type_concept_test.rb
@@ -18,7 +18,7 @@ describe ConceptQL::Operators::DrugTypeConcept do
       ["drug_type_concept",
        ["icd9", "412", {:annotation=>{:counts=>{:condition_occurrence=>{:rows=>50, :n=>38}}}, :name=>"ICD-9 CM"}],
        2,
-       {:annotation=>{:counts=>{:condition_occurrence=>{:rows=>0, :n=>0}}, :errors=>[["has upstreams"]]}}]
+       {:annotation=>{:counts=>{:condition_occurrence=>{:rows=>0, :n=>0}}, :errors=>[["has upstreams", ["icd9"]]]}}]
     )
 
     query(

--- a/test/operators/first_test.rb
+++ b/test/operators/first_test.rb
@@ -25,7 +25,7 @@ describe ConceptQL::Operators::First do
     query(
       [:first, 1]
     ).annotate.must_equal(
-      ["first", 1, {:annotation=>{:counts=>{:invalid=>{:rows=>0, :n=>0}}, :errors=>[["has no upstream"], ["has arguments"]]}}]
+      ["first", 1, {:annotation=>{:counts=>{:invalid=>{:rows=>0, :n=>0}}, :errors=>[["has no upstream"], ["has arguments", [1]]]}}]
     )
   end
 end

--- a/test/operators/from_seer_visits_test.rb
+++ b/test/operators/from_seer_visits_test.rb
@@ -36,7 +36,7 @@ describe ConceptQL::Operators::FromSeerVisits do
        ["visit_occurrence",
         ["icd9", "412", {:annotation=>{:counts=>{:condition_occurrence=>{:rows=>50, :n=>38}}}, :name=>"ICD-9 CM"}],
         {:annotation=>{:counts=>{:visit_occurrence=>{:rows=>50, :n=>38}}}}],
-       {:annotation=>{:counts=>{:visit_occurrence=>{:n=>0, :rows=>0}}, :errors=>[["has multiple upstreams"]]}}]
+       {:annotation=>{:counts=>{:visit_occurrence=>{:n=>0, :rows=>0}}, :errors=>[["has multiple upstreams", ["visit_occurrence", "visit_occurrence"]]]}}]
     )
   end
 end

--- a/test/operators/from_test.rb
+++ b/test/operators/from_test.rb
@@ -27,7 +27,7 @@ describe ConceptQL::Operators::From do
     ).annotate.must_equal(
       ["from",
        ["icd9", "412", {:annotation=>{:counts=>{:condition_occurrence=>{:rows=>50, :n=>38}}}, :name=>"ICD-9 CM"}],
-       {:annotation=>{:counts=>{:invalid=>{:n=>0, :rows=>0}}, :errors=>[["has upstreams"], ["has no arguments"]]}}]
+       {:annotation=>{:counts=>{:invalid=>{:n=>0, :rows=>0}}, :errors=>[["has upstreams", ["icd9"]], ["has no arguments"]]}}]
     )
 
     query(

--- a/test/operators/from_test.rb
+++ b/test/operators/from_test.rb
@@ -36,7 +36,7 @@ describe ConceptQL::Operators::From do
       ["from",
        'person',
        'observation_period',
-       {:annotation=>{:counts=>{:observation_period=>{:n=>0, :rows=>0}}, :errors=>[["has multiple arguments"]]}}]
+       {:annotation=>{:counts=>{:observation_period=>{:n=>0, :rows=>0}}, :errors=>[["has multiple arguments", ["person", "observation_period"]]]}}]
     )
   end
 end

--- a/test/operators/gender_test.rb
+++ b/test/operators/gender_test.rb
@@ -13,7 +13,7 @@ describe ConceptQL::Operators::Gender do
     ).annotate.must_equal(
       ["gender",
        ["icd9", "412", {:annotation=>{:counts=>{:condition_occurrence=>{:rows=>50, :n=>38}}}, :name=>"ICD-9 CM"}],
-       {:annotation=>{:counts=>{:person=>{:rows=>0, :n=>0}}, :errors=>[["has upstreams"], ["has no arguments"]]}}]
+       {:annotation=>{:counts=>{:person=>{:rows=>0, :n=>0}}, :errors=>[["has upstreams", ["icd9"]], ["has no arguments"]]}}]
     )
   end
 end

--- a/test/operators/icd10_test.rb
+++ b/test/operators/icd10_test.rb
@@ -13,7 +13,7 @@ describe ConceptQL::Operators::Icd10 do
     ).annotate.must_equal(
       ["icd10",
        ["icd9", "412", {:annotation=>{:counts=>{:condition_occurrence=>{:rows=>50, :n=>38}}}, :name=>"ICD-9 CM"}],
-       {:annotation=>{:counts=>{:condition_occurrence=>{:n=>0, :rows=>0}}, :errors=>[["has upstreams"], ["has no arguments"]]}, :name=>"ICD-10 CM"}]
+       {:annotation=>{:counts=>{:condition_occurrence=>{:n=>0, :rows=>0}}, :errors=>[["has upstreams", ["icd9"]], ["has no arguments"]]}, :name=>"ICD-10 CM"}]
     )
   end
 end

--- a/test/operators/intersect_test.rb
+++ b/test/operators/intersect_test.rb
@@ -39,7 +39,7 @@ describe ConceptQL::Operators::Intersect do
     query(
       [:intersect, 1]
     ).annotate.must_equal(
-      ["intersect", 1, {:annotation=>{:counts=>{:invalid=>{:n=>0, :rows=>0}}, :errors=>[["has no upstream"], ["has arguments"]]}}]
+      ["intersect", 1, {:annotation=>{:counts=>{:invalid=>{:n=>0, :rows=>0}}, :errors=>[["has no upstream"], ["has arguments", [1]]]}}]
     )
   end
 end

--- a/test/operators/invalid_test.rb
+++ b/test/operators/invalid_test.rb
@@ -11,11 +11,11 @@ describe ConceptQL::Operators::Invalid do
 
   it "should annotate left and right options if provided" do
     query(
-      [:bad_op, {left: [:icd9, "412"], right: [:icd9, "410"]}]
+      [:bad_op, {left: [:icd9, "412"], right: [:icd9, "ZZZZZZZ"]}]
     ).annotate.must_equal(
       ["bad_op", {
         :left=>["icd9", "412", {:annotation=>{:counts=>{:condition_occurrence=>{:rows=>50, :n=>38}}}, :name=>"ICD-9 CM"}],
-        :right=>["icd9", "410", {:annotation=>{:counts=>{:condition_occurrence=>{:rows=>0, :n=>0}}}, :name=>"ICD-9 CM"}],
+        :right=>["icd9", "ZZZZZZZ", {:annotation=>{:counts=>{:condition_occurrence=>{:rows=>0, :n=>0}}, :warnings=>[["invalid source code", "ZZZZZZZ"]]}, :name=>"ICD-9 CM"}],
         :annotation=>{:counts=>{:invalid=>{:rows=>0, :n=>0}}, :errors=>[["invalid operator", :bad_op]]}}]
     )
   end

--- a/test/operators/numeric_test.rb
+++ b/test/operators/numeric_test.rb
@@ -22,7 +22,7 @@ describe ConceptQL::Operators::Numeric do
       ["numeric",
        ["icd9", "412", {:annotation=>{:counts=>{:condition_occurrence=>{:rows=>50, :n=>38}}}, :name=>"ICD-9 CM"}],
        ["icd9_procedure", "00.13", {:annotation=>{:counts=>{:procedure_occurrence=>{:rows=>1, :n=>1}}}, :name=>"ICD-9 Proc"}],
-       {:annotation=>{:counts=>{:procedure_occurrence=>{:rows=>0, :n=>0}, :condition_occurrence=>{:n=>0, :rows=>0}}, :errors=>[["has multiple upstreams"], ["has no arguments"]]}}]
+       {:annotation=>{:counts=>{:procedure_occurrence=>{:rows=>0, :n=>0}, :condition_occurrence=>{:n=>0, :rows=>0}}, :errors=>[["has multiple upstreams", ["icd9", "icd9_procedure"]], ["has no arguments"]]}}]
     )
   end
 end

--- a/test/operators/observation_period_test.rb
+++ b/test/operators/observation_period_test.rb
@@ -22,7 +22,7 @@ describe ConceptQL::Operators::ObservationPeriod do
       ["observation_period",
        ["icd9", "412", {:annotation=>{:counts=>{:condition_occurrence=>{:rows=>50, :n=>38}}}, :name=>"ICD-9 CM"}],
        ["gender", "Male", {:annotation=>{:counts=>{:person=>{:rows=>126, :n=>126}}}}],
-       {:annotation=>{:counts=>{:observation_period=>{:n=>0, :rows=>0}}, :errors=>[["has multiple upstreams"]]}}]
+       {:annotation=>{:counts=>{:observation_period=>{:n=>0, :rows=>0}}, :errors=>[["has multiple upstreams", ["icd9", "gender"]]]}}]
     )
 
     query(
@@ -31,7 +31,7 @@ describe ConceptQL::Operators::ObservationPeriod do
       ["observation_period",
        ["gender", "Male", {:annotation=>{:counts=>{:person=>{:rows=>126, :n=>126}}}}],
        1,
-       {:annotation=>{:counts=>{:observation_period=>{:n=>0, :rows=>0}}, :errors=>[["has arguments"]]}}]
+       {:annotation=>{:counts=>{:observation_period=>{:n=>0, :rows=>0}}, :errors=>[["has arguments", [1]]]}}]
     )
   end
 end

--- a/test/operators/one_in_two_out_test.rb
+++ b/test/operators/one_in_two_out_test.rb
@@ -19,14 +19,14 @@ describe ConceptQL::Operators::OneInTwoOut do
       [:one_in_two_out, {:gap=>30, :blah=>true}]
     ).annotate.must_equal(
       ["one_in_two_out",{:gap=>30, :blah=>true,
-                         :annotation=>{:counts=>{:invalid=>{:rows=>0, :n=>0}}, :errors=>[["has no upstream"], ["required option not present", "outpatient_minimum_gap"]]}}]
+                         :annotation=>{:counts=>{:invalid=>{:rows=>0, :n=>0}}, :errors=>[["has no upstream"]]}}]
     )
 
     query(
       [:one_in_two_out, 1, {:gap=>30, :blah=>true}]
     ).annotate.must_equal(
       ["one_in_two_out", 1, {:gap=>30, :blah=>true,
-                             :annotation=>{:counts=>{:invalid=>{:rows=>0, :n=>0}}, :errors=>[["has no upstream"], ["has arguments"], ["required option not present", "outpatient_minimum_gap"]]}}]
+                             :annotation=>{:counts=>{:invalid=>{:rows=>0, :n=>0}}, :errors=>[["has no upstream"], ["has arguments", [1]]]}}]
     )
 
     query(
@@ -36,7 +36,7 @@ describe ConceptQL::Operators::OneInTwoOut do
        ["icd9", "412", {:annotation=>{:counts=>{:condition_occurrence=>{:rows=>50, :n=>38}}}, :name=>"ICD-9 CM"}],
        ["icd9", "412", {:annotation=>{:counts=>{:condition_occurrence=>{:rows=>50, :n=>38}}}, :name=>"ICD-9 CM"}],
        {:gap=>30, :blah=>true,
-        :annotation=>{:counts=>{:condition_occurrence=>{:rows=>0, :n=>0}}, :errors=>[["has multiple upstreams"], ["required option not present", "outpatient_minimum_gap"]]}}]
+        :annotation=>{:counts=>{:condition_occurrence=>{:rows=>0, :n=>0}}, :errors=>[["has multiple upstreams", ["icd9", "icd9"]]]}}]
     )
   end
 end

--- a/test/operators/person_test.rb
+++ b/test/operators/person_test.rb
@@ -18,7 +18,7 @@ describe ConceptQL::Operators::Person do
       ["person",
        ["icd9", "412", {:annotation=>{:counts=>{:condition_occurrence=>{:rows=>50, :n=>38}}}, :name=>"ICD-9 CM"}],
        ["icd9", "412", {:annotation=>{:counts=>{:condition_occurrence=>{:rows=>50, :n=>38}}}, :name=>"ICD-9 CM"}],
-       {:annotation=>{:counts=>{:person=>{:n=>0, :rows=>0}}, :errors=>[["has multiple upstreams"]]}}]
+       {:annotation=>{:counts=>{:person=>{:n=>0, :rows=>0}}, :errors=>[["has multiple upstreams", ["icd9", "icd9"]]]}}]
     )
 
     query(
@@ -26,7 +26,7 @@ describe ConceptQL::Operators::Person do
     ).annotate.must_equal(
       ["person",
        "412",
-       {:annotation=>{:counts=>{:person=>{:n=>0, :rows=>0}}, :errors=>[["has arguments"]]}}]
+       {:annotation=>{:counts=>{:person=>{:n=>0, :rows=>0}}, :errors=>[["has arguments", ["412"]]]}}]
     )
   end
 end

--- a/test/operators/place_of_service_code_test.rb
+++ b/test/operators/place_of_service_code_test.rb
@@ -14,7 +14,7 @@ describe ConceptQL::Operators::PlaceOfServiceCode do
       ["place_of_service_code",
        ["icd9", "412", {:annotation=>{:counts=>{:condition_occurrence=>{:rows=>50, :n=>38}}}, :name=>"ICD-9 CM"}],
        21,
-       {:annotation=>{:counts=>{:visit_occurrence=>{:n=>0, :rows=>0}}, :errors=>[["has upstreams"]]}}]
+       {:annotation=>{:counts=>{:visit_occurrence=>{:n=>0, :rows=>0}}, :errors=>[["has upstreams", ["icd9"]]]}}]
     )
 
     query(

--- a/test/operators/procedure_occurence_test.rb
+++ b/test/operators/procedure_occurence_test.rb
@@ -25,7 +25,7 @@ describe ConceptQL::Operators::ProcedureOccurrence do
       ["procedure_occurrence",
        ["icd9", "412", {:annotation=>{:counts=>{:condition_occurrence=>{:rows=>50, :n=>38}}}, :name=>"ICD-9 CM"}],
        ["gender", "Male", {:annotation=>{:counts=>{:person=>{:rows=>126, :n=>126}}}}],
-       {:annotation=>{:counts=>{:procedure_occurrence=>{:n=>0, :rows=>0}}, :errors=>[["has multiple upstreams"]]}}]
+       {:annotation=>{:counts=>{:procedure_occurrence=>{:n=>0, :rows=>0}}, :errors=>[["has multiple upstreams", ["icd9", "gender"]]]}}]
     )
 
     query(
@@ -34,7 +34,7 @@ describe ConceptQL::Operators::ProcedureOccurrence do
       ["procedure_occurrence",
        ["icd9", "412", {:annotation=>{:counts=>{:condition_occurrence=>{:rows=>50, :n=>38}}}, :name=>"ICD-9 CM"}],
        21,
-       {:annotation=>{:counts=>{:procedure_occurrence=>{:n=>0, :rows=>0}}, :errors=>[["has arguments"]]}}]
+       {:annotation=>{:counts=>{:procedure_occurrence=>{:n=>0, :rows=>0}}, :errors=>[["has arguments", [21]]]}}]
     )
   end
 end

--- a/test/operators/race_test.rb
+++ b/test/operators/race_test.rb
@@ -14,7 +14,7 @@ describe ConceptQL::Operators::Race do
       ["race",
        ["icd9", "412", {:annotation=>{:counts=>{:condition_occurrence=>{:rows=>50, :n=>38}}}, :name=>"ICD-9 CM"}],
        "Black or African American",
-       {:annotation=>{:counts=>{:person=>{:n=>0, :rows=>0}}, :errors=>[["has upstreams"]]}}]
+       {:annotation=>{:counts=>{:person=>{:n=>0, :rows=>0}}, :errors=>[["has upstreams", ["icd9"]]]}}]
     )
 
     query(

--- a/test/operators/recall_test.rb
+++ b/test/operators/recall_test.rb
@@ -113,7 +113,7 @@ describe ConceptQL::Operators::Recall do
     query(
       [:recall, "foo", "bar"]
     ).annotate.must_equal(
-      ["recall", "foo", "bar", {:annotation=>{:counts=>{:invalid=>{:rows=>0, :n=>0}}, :errors=>[["has multiple arguments"]]}}]
+      ["recall", "foo", "bar", {:annotation=>{:counts=>{:invalid=>{:rows=>0, :n=>0}}, :errors=>[["has multiple arguments", ["foo", "bar"]]]}}]
     )
 
     query(

--- a/test/operators/recall_test.rb
+++ b/test/operators/recall_test.rb
@@ -94,7 +94,7 @@ describe ConceptQL::Operators::Recall do
        ["recall",
         ["icd9", "412", {:annotation=>{:counts=>{:condition_occurrence=>{:rows=>50, :n=>38}}}, :name=>"ICD-9 CM"}],
         "Heart Attack",
-        {:annotation=>{:counts=>{:condition_occurrence=>{:rows=>0, :n=>0}}, :errors=>[["has upstreams"]]}}],
+        {:annotation=>{:counts=>{:condition_occurrence=>{:rows=>0, :n=>0}}, :errors=>[["has upstreams", ["icd9"]]]}}],
       {:annotation=>{:counts=>{:condition_occurrence=>{:rows=>0, :n=>0}}}}]
     )
 

--- a/test/operators/sum_test.rb
+++ b/test/operators/sum_test.rb
@@ -28,7 +28,7 @@ describe ConceptQL::Operators::Sum do
       ["sum",
        ["numeric", 1, {:annotation=>{:counts=>{:person=>{:rows=>250, :n=>250}}}}],
        21,
-       {:annotation=>{:counts=>{:person=>{:rows=>0, :n=>0}}, :errors=>[["has arguments"]]}}]
+       {:annotation=>{:counts=>{:person=>{:rows=>0, :n=>0}}, :errors=>[["has arguments", [21]]]}}]
     )
   end
 end

--- a/test/operators/time_window_test.rb
+++ b/test/operators/time_window_test.rb
@@ -48,7 +48,7 @@ describe ConceptQL::Operators::TimeWindow do
       ["time_window",
        ["icd9", "412", {:annotation=>{:counts=>{:condition_occurrence=>{:rows=>50, :n=>38}}}, :name=>"ICD-9 CM"}],
        21,
-       {:start=>"-2y", :end=>"-2y", :annotation=>{:counts=>{:condition_occurrence=>{:n=>0, :rows=>0}}, :errors=>[["has arguments"]]}}]
+       {:start=>"-2y", :end=>"-2y", :annotation=>{:counts=>{:condition_occurrence=>{:n=>0, :rows=>0}}, :errors=>[["has arguments", [21]]]}}]
     )
 
     query(
@@ -57,7 +57,7 @@ describe ConceptQL::Operators::TimeWindow do
       ["time_window",
        ["icd9", "412", {:annotation=>{:counts=>{:condition_occurrence=>{:rows=>50, :n=>38}}}, :name=>"ICD-9 CM"}],
        ["place_of_service_code", "21", {:annotation=>{:counts=>{:visit_occurrence=>{:rows=>170, :n=>92}}}}],
-       {:start=>"-2y", :end=>"-2y", :annotation=>{:counts=>{:visit_occurrence=>{:rows=>0, :n=>0}, :condition_occurrence=>{:n=>0, :rows=>0}},:errors=>[["has multiple upstreams"]]}}]
+       {:start=>"-2y", :end=>"-2y", :annotation=>{:counts=>{:visit_occurrence=>{:rows=>0, :n=>0}, :condition_occurrence=>{:n=>0, :rows=>0}},:errors=>[["has multiple upstreams", ["icd9", "place_of_service_code"]]]}}]
     )
   end
 end

--- a/test/operators/trim_date_end_test.rb
+++ b/test/operators/trim_date_end_test.rb
@@ -20,4 +20,13 @@ describe ConceptQL::Operators::TrimDateEnd do
         :right=>[:date_range, {:start=>"2008-02-17", :end=>"2010-12-01"}]}]
     ).must_equal("condition_occurrence"=>[21006, 24721])
   end
+
+  it "should produce correct results when using :within option" do
+    criteria_ids(
+      [:trim_date_end,
+       {:left=>[:icd9, "412"],
+        :right=>[:date_range, {:start=>"2008-02-17", :end=>"2010-12-01"}],
+        :within=>'3d'}]
+    ).must_equal("condition_occurrence"=>[24721])
+  end
 end

--- a/test/operators/trim_date_end_test.rb
+++ b/test/operators/trim_date_end_test.rb
@@ -29,4 +29,20 @@ describe ConceptQL::Operators::TrimDateEnd do
         :within=>'3d'}]
     ).must_equal("condition_occurrence"=>[24721])
   end
+
+  it "should produce correct results when using :occurrences option" do
+    criteria_ids(
+      [:trim_date_end,
+       {:left=>[:icd9, "412"],
+        :right=>[:date_range, {:start=>"2008-02-17", :end=>"2010-12-01"}],
+        :occurrences=>1}]
+    ).must_equal({})
+
+    criteria_ids(
+      [:trim_date_end,
+       {:left=>[:icd9, "412"],
+        :right=>[:date_range, {:start=>"2008-02-17", :end=>"2010-12-01"}],
+        :occurrences=>0}]
+    ).must_equal("condition_occurrence"=>[21006, 24721])
+  end
 end

--- a/test/operators/trim_date_start_test.rb
+++ b/test/operators/trim_date_start_test.rb
@@ -20,4 +20,13 @@ describe ConceptQL::Operators::TrimDateStart do
         :right=>[:date_range, {:start=>"2008-03-14", :end=>"2010-11-22"}]}]
     ).must_equal("condition_occurrence"=>[17774, 21619])
   end
+
+  it "should produce correct results when using :within option" do
+    criteria_ids(
+      [:trim_date_start,
+       {:left=>[:icd9, "412"],
+        :right=>[:date_range, {:start=>"2008-03-14", :end=>"2010-11-22"}],
+        :within=>'3d'}]
+    ).must_equal("condition_occurrence"=>[17774])
+  end
 end

--- a/test/operators/trim_date_start_test.rb
+++ b/test/operators/trim_date_start_test.rb
@@ -29,4 +29,20 @@ describe ConceptQL::Operators::TrimDateStart do
         :within=>'3d'}]
     ).must_equal("condition_occurrence"=>[17774])
   end
+
+  it "should produce correct results when using :occurrences option" do
+    criteria_ids(
+      [:trim_date_start,
+       {:left=>[:icd9, "412"],
+        :right=>[:date_range, {:start=>"2008-03-14", :end=>"2010-11-22"}],
+        :occurrences=>1}]
+    ).must_equal({})
+
+    criteria_ids(
+      [:trim_date_start,
+       {:left=>[:icd9, "412"],
+        :right=>[:date_range, {:start=>"2008-03-14", :end=>"2010-11-22"}],
+        :occurrences=>0}]
+    ).must_equal("condition_occurrence"=>[17774, 21619])
+  end
 end

--- a/test/operators/union_test.rb
+++ b/test/operators/union_test.rb
@@ -120,7 +120,7 @@ describe ConceptQL::Operators::Union do
     query(
       [:union, "123"]
     ).annotate.must_equal(
-      ["union", "123", {:annotation=>{:counts=>{:invalid=>{:rows=>0, :n=>0}}, :errors=>[["has no upstream"], ["has arguments"]]}}]
+      ["union", "123", {:annotation=>{:counts=>{:invalid=>{:rows=>0, :n=>0}}, :errors=>[["has no upstream"], ["has arguments", ["123"]]]}}]
     )
 
     query(

--- a/test/operators/visit_occurrence_test.rb
+++ b/test/operators/visit_occurrence_test.rb
@@ -22,7 +22,7 @@ describe ConceptQL::Operators::VisitOccurrence do
       ["visit_occurrence",
        ["icd9", "412", {:annotation=>{:counts=>{:condition_occurrence=>{:rows=>50, :n=>38}}}, :name=>"ICD-9 CM"}],
        ["icd9", "412", {:annotation=>{:counts=>{:condition_occurrence=>{:rows=>50, :n=>38}}}, :name=>"ICD-9 CM"}],
-       {:annotation=>{:counts=>{:visit_occurrence=>{:n=>0,:rows=>0}}, :errors=>[["has multiple upstreams"]]}}]
+       {:annotation=>{:counts=>{:visit_occurrence=>{:n=>0,:rows=>0}}, :errors=>[["has multiple upstreams", ["icd9", "icd9"]]]}}]
     )
 
     query(
@@ -31,7 +31,7 @@ describe ConceptQL::Operators::VisitOccurrence do
       ["visit_occurrence",
        ["icd9", "412", {:annotation=>{:counts=>{:condition_occurrence=>{:rows=>50, :n=>38}}}, :name=>"ICD-9 CM"}],
        21,
-       {:annotation=>{:counts=>{:visit_occurrence=>{:rows=>0, :n=>0}}, :errors=>[["has arguments"]]}}]
+       {:annotation=>{:counts=>{:visit_occurrence=>{:rows=>0, :n=>0}}, :errors=>[["has arguments", [21]]]}}]
     )
   end
 end

--- a/test/query_test.rb
+++ b/test/query_test.rb
@@ -5,7 +5,7 @@ describe ConceptQL::Query do
     query(
       :foo
     ).annotate.must_equal(
-      ["invalid", {:annotation=>{:counts=>{:invalid=>{:n=>0, :rows=>0}}, :errors=>[["invalid root operator"]]}}]
+      ["invalid", {:annotation=>{:counts=>{:invalid=>{:n=>0, :rows=>0}}, :errors=>[["invalid root operator", ":foo"]]}}]
     )
   end
 end


### PR DESCRIPTION
This was a little more complicated than I expected.  Some temporal
operators only have a end_date or a start_date on the RHS, not
both, so the appropriate :within filter needs to be skipped in
such cases.

For example, in the after operator, the LHS start date needs to
fall after the RHS end date, so there is no point in checking that
the LHS start date falls before the start date less the within
interval.  Similarly for the before, trim_date_end, and
trim_date_start operators.

In order to handle date adjustments in both directions from the
same DateAdjuster, I added an optional second argument to
DateAdjuster#adjust for reversing the quantity.

Note that the current code allow for reverse :within intervals,
allowing you to check for a date inside the RHS start and end dates
by the interval instead of outside.  I'm not sure if this has a
practical use, though I did need to use it in the any_overlap
spec.

I'm not sure in which conditions you want to choose with LHS date
column to use for within.  The spec says after uses the LHS start
date and before uses the LHS end date.  I defaulted
TemporalOperator to use the LHS start date, and then overrode
before and trim_date_end to use the LHS end date.

This does not add tests for all temporal operators, but the
remaining ones only override where_clause and thus should
function similarly to any_overlap, which I did add a test for.

This also fixes the tests for validation error details, which
I had to do before starting work so I could be sure that
implementing :within wouldn't break existing code.