### PR TITLE
Support :at_least TemporalOperator option

### DIFF
--- a/lib/conceptql/operators/temporal_operator.rb
+++ b/lib/conceptql/operators/temporal_operator.rb
@@ -38,6 +38,10 @@ module ConceptQL
           ds = add_within_condition(ds, within)
         end
 
+        if at_least = options[:at_least]
+          ds = add_within_condition(ds, at_least, :exclude)
+        end
+
         if occurrences = options[:occurrences]
           ds = add_occurrences_condition(ds, occurrences)
         end
@@ -45,13 +49,13 @@ module ConceptQL
         ds
       end
 
-      def add_within_condition(ds, within)
+      def add_within_condition(ds, within, meth=:where)
         within = DateAdjuster.new(within)
         after = within.adjust(:r__start_date, true)
         before = within.adjust(:r__end_date)
         within_col = Sequel.expr(within_column)
-        ds = ds.where{within_col >= after} if within_check_after?
-        ds = ds.where{within_col <= before} if within_check_before?
+        ds = ds.send(meth){within_col >= after} if within_check_after?
+        ds = ds.send(meth){within_col <= before} if within_check_before?
         ds
       end
 

--- a/test/operators/after_test.rb
+++ b/test/operators/after_test.rb
@@ -18,6 +18,15 @@ describe ConceptQL::Operators::After do
     ).must_equal("condition_occurrence"=>[32104, 32981])
   end
 
+  it "should produce correct results when using :at_least option" do
+    criteria_ids(
+      [:after,
+       {:left=>[:icd9, "412"],
+        :right=>[:time_window, [:gender, "Male"], {:start=>"50y", :end=>"50y"}],
+        :at_least=>"15000d"}]
+    ).must_equal("condition_occurrence"=>[24707, 24721, 26766])
+  end
+
   it "should produce correct results when using :occurrences option" do
     criteria_ids(
       [:after,

--- a/test/operators/any_overlap_test.rb
+++ b/test/operators/any_overlap_test.rb
@@ -24,6 +24,15 @@ describe ConceptQL::Operators::AnyOverlap do
     ).must_equal("condition_occurrence"=>[10443, 13741, 24989, 31877])
   end
 
+  it "should produce correct results when using :at_least option" do
+    criteria_ids(
+      [:any_overlap,
+       {:left=>[:icd9, "412"],
+        :right=>[:date_range, {:start=>"2010-01-01", :end=>"2010-12-31"}],
+        :at_least =>'-200d'}]
+    ).must_equal("condition_occurrence"=>[13741, 24989])
+  end
+
   it "should produce correct results when using :occurrences option" do
     criteria_ids(
       [:any_overlap,

--- a/test/operators/before_test.rb
+++ b/test/operators/before_test.rb
@@ -17,6 +17,12 @@ describe ConceptQL::Operators::Before do
     ).must_equal("condition_occurrence"=>[13741, 17774, 31542])
   end
 
+  it "should produce correct results when using :at_least option" do
+    criteria_ids(
+      [:before, {:left=>[:icd9, "412"], :right=>[:icd9, "401.9"], :at_least=>'900d'}]
+    ).must_equal("condition_occurrence"=>[21006, 24721])
+  end
+
   it "should produce correct results when using :occurrences option" do
     criteria_ids(
       [:before, {:left=>[:icd9, "412"], :right=>[:icd9, "401.9"], :occurrences=>1}]

--- a/test/operators/trim_date_end_test.rb
+++ b/test/operators/trim_date_end_test.rb
@@ -30,6 +30,15 @@ describe ConceptQL::Operators::TrimDateEnd do
     ).must_equal("condition_occurrence"=>[24721])
   end
 
+  it "should produce correct results when using :at_least option" do
+    criteria_ids(
+      [:trim_date_end,
+       {:left=>[:icd9, "412"],
+        :right=>[:date_range, {:start=>"2008-02-17", :end=>"2010-12-01"}],
+        :at_least=>'30d'}]
+    ).must_equal("condition_occurrence"=>[21006])
+  end
+
   it "should produce correct results when using :occurrences option" do
     criteria_ids(
       [:trim_date_end,

--- a/test/operators/trim_date_start_test.rb
+++ b/test/operators/trim_date_start_test.rb
@@ -30,6 +30,15 @@ describe ConceptQL::Operators::TrimDateStart do
     ).must_equal("condition_occurrence"=>[17774])
   end
 
+  it "should produce correct results when using :at_least option" do
+    criteria_ids(
+      [:trim_date_start,
+       {:left=>[:icd9, "412"],
+        :right=>[:date_range, {:start=>"2008-03-14", :end=>"2010-11-22"}],
+        :at_least=>'30d'}]
+    ).must_equal("condition_occurrence"=>[21619])
+  end
+
   it "should produce correct results when using :occurrences option" do
     criteria_ids(
       [:trim_date_start,


### PR DESCRIPTION
:at_least appears to be an inverse of :within, so just add a way to
invert the within condition and use that.