### PR TITLE
Fix deprecation warnings related to symbol splitting and filter arguments

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,8 @@
-require "bundler/gem_tasks"
+begin
+  require "bundler/gem_tasks"
+rescue LoadError
+end
+
 ENV['DATA_MODEL'] ||= 'omopv4_plus'
 
 desc "Setup test database"

--- a/Rakefile
+++ b/Rakefile
@@ -15,11 +15,6 @@ run_spec = lambda do |data_model|
   sh "DATA_MODEL=#{data_model} #{FileUtils::RUBY} test/all.rb"
 end
 
-desc "Run tests with omopv4 data model"
-task :test_omopv4 do
-  run_spec.call(:omopv4)
-end
-
 desc "Run tests with omopv4_plus data model"
 task :test_omopv4_plus do
   run_spec.call(:omopv4_plus)
@@ -33,8 +28,8 @@ end
 desc "Run tests with omopv4 data model with coverage"
 task :test_cov do
   ENV['COVERAGE'] = '1'
-  run_spec.call(:omopv4)
+  run_spec.call(:omopv4_plus)
 end
 
 desc "Run tests with omopv4 data model"
-task :default => :test_omopv4
+task :default => :test_omopv4_plus

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,5 @@
 require "bundler/gem_tasks"
-ENV['DATA_MODEL'] ||= 'omopv4'
+ENV['DATA_MODEL'] ||= 'omopv4_plus'
 
 desc "Setup test database"
 task :test_db_setup do

--- a/lib/conceptql/data_model/omopv4_plus.rb
+++ b/lib/conceptql/data_model/omopv4_plus.rb
@@ -345,7 +345,13 @@ module ConceptQL
       def table_to_sym(table)
         case table
         when Symbol
-          table = Sequel.split_symbol(table)[1].to_sym
+          table = Sequel.split_symbol(table)[1].to_sym if Sequel.split_symbols?
+        when Sequel::SQL::AliasedExpression
+          table = table.expression
+        when Sequel::SQL::QualifiedIdentifier
+          table = table.column
+        when Sequel::SQL::Identifier
+          table = table.value
         end
         table
       end

--- a/lib/conceptql/nodifier.rb
+++ b/lib/conceptql/nodifier.rb
@@ -35,7 +35,7 @@ module ConceptQL
     private
 
     def operators
-      @operators ||= Operators.operators[@data_model]
+      @operators ||= Operators.operators.fetch(@data_model)
     end
 
     def invalid_op(operator, values, *error_args)

--- a/lib/conceptql/operators/after.rb
+++ b/lib/conceptql/operators/after.rb
@@ -30,7 +30,7 @@ R-----R
       end
 
       def where_clause
-        Proc.new { l__start_date > r__end_date }
+        Sequel.expr { l[:start_date] > r[:end_date] }
       end
 
       def compare_all?

--- a/lib/conceptql/operators/any_overlap.rb
+++ b/lib/conceptql/operators/any_overlap.rb
@@ -7,9 +7,7 @@ module ConceptQL
 
       desc 'If a result in the LHR overlaps in any way a result in the RHR, it is passed through.'
       def where_clause
-        l_partly_in_r = Sequel.expr { r__start_date <= l__start_date }.&(Sequel.expr { l__start_date <= r__end_date })
-        r_partly_in_l = Sequel.expr { l__start_date <= r__start_date }.&(Sequel.expr { r__start_date <= l__end_date })
-        l_partly_in_r.|(r_partly_in_l)
+        Sequel.expr { ((r[:start_date] <= l[:start_date]) & (l[:start_date] <= r[:end_date])) | ((l[:start_date] <= r[:start_date]) & (r[:start_date] <= l[:end_date])) }
       end
     end
   end

--- a/lib/conceptql/operators/before.rb
+++ b/lib/conceptql/operators/before.rb
@@ -22,11 +22,11 @@ All other results are discarded, including all results in the RHR.
       end
 
       def within_column
-        :l__end_date
+        Sequel[:l][:end_date]
       end
 
       def where_clause
-        Proc.new { l__end_date < r__start_date }
+        Sequel.expr { l[:end_date] < r[:start_date] }
       end
 
       def compare_all?

--- a/lib/conceptql/operators/co_reported.rb
+++ b/lib/conceptql/operators/co_reported.rb
@@ -41,9 +41,9 @@ module ConceptQL
 
       def contextify(db, stream)
         stream.evaluate(db).from_self(alias: :s)
-          .join(:clinical_codes___c, c__id: :s__criterion_id)
+          .join(Sequel[:clinical_codes].as(:c), id: :criterion_id)
           .select_all(:s)
-          .select_append(:c__context_id___context_id)
+          .select_append(Sequel[:c][:context_id].as(:context_id))
           .from_self
       end
 
@@ -52,8 +52,8 @@ module ConceptQL
       def visit_occurrence_ids_in_common(db)
         @visit_occurrence_ids_in_common ||= upstream_queries(db).map { |q| q.select(:visit_occurrence_id) }.inject do |q, query|
           q.from_self(alias: :tab1)
-            .join(query.as(:tab2), tab1__visit_occurrence_id: :tab2__visit_occurrence_id)
-            .select(:tab1__visit_occurrence_id___visit_occurrence_id)
+            .join(query.as(:tab2), visit_occurrence_id: :visit_occurrence_id)
+            .select(Sequel[:tab1][:visit_occurrence_id].as(:visit_occurrence_id))
         end
       end
 

--- a/lib/conceptql/operators/concurrent_within.rb
+++ b/lib/conceptql/operators/concurrent_within.rb
@@ -24,8 +24,8 @@ module ConceptQL
 
         return datasets.first.from_self if datasets.length == 1
 
-        adjusted_start_date = DateAdjuster.new(self, options[:start]).adjust(:l__start_date, true)
-        adjusted_end_date = DateAdjuster.new(self, options[:end]).adjust(:l__end_date)
+        adjusted_start_date = DateAdjuster.new(self, options[:start]).adjust(Sequel[:l][:start_date], true)
+        adjusted_end_date = DateAdjuster.new(self, options[:end]).adjust(Sequel[:l][:end_date])
 
         datasets = datasets.map do |ds|
           matching = ds.from_self(:alias=>:l)
@@ -33,8 +33,8 @@ module ConceptQL
           (datasets - [ds]).each do |other|
             other = other
               .from_self(:alias=>:r)
-              .where(adjusted_start_date <= :r__start_date)
-              .where(adjusted_end_date >= :r__end_date)
+              .where(adjusted_start_date <= Sequel[:r][:start_date])
+              .where(adjusted_end_date >= Sequel[:r][:end_date])
               .select(:person_id)
 
             matching = matching.where(:person_id=>other)

--- a/lib/conceptql/operators/contains.rb
+++ b/lib/conceptql/operators/contains.rb
@@ -14,7 +14,7 @@ L------Y--------L
       EOF
 
       def where_clause
-        [Proc.new { l__start_date <= r__start_date}, Proc.new { r__end_date <= l__end_date }]
+        Sequel.expr{ (l[:start_date] <= r[:start_date]) & (r[:end_date] <= l[:end_date]) }
       end
     end
   end

--- a/lib/conceptql/operators/during.rb
+++ b/lib/conceptql/operators/during.rb
@@ -13,10 +13,9 @@ All other results are discarded, including all results in the RHR.
 
       def where_clause
         if inclusive?
-          Sequel.expr(Sequel.expr(Proc.new { r__start_date <= l__start_date}).&(Sequel.expr( Proc.new { l__start_date <= r__end_date })))
-            .|(Sequel.expr(Proc.new { r__start_date <= l__end_date}).&(Sequel.expr( Proc.new { l__end_date <= r__end_date })))
+          Sequel.expr{ ((r[:start_date] <= l[:start_date]) & (l[:start_date] <= r[:end_date])) | ((r[:start_date] <= l[:end_date]) & (l[:end_date] <= r[:end_date])) }
         else
-          [Proc.new { r__start_date <= l__start_date}, Proc.new { l__end_date <= r__end_date }]
+          Sequel.expr{ (r[:start_date] <= l[:start_date]) & (l[:end_date] <= r[:end_date]) }
         end
       end
     end

--- a/lib/conceptql/operators/equal.rb
+++ b/lib/conceptql/operators/equal.rb
@@ -9,7 +9,7 @@ module ConceptQL
       require_column :value_as_number
 
       def where_clause
-        { r__value_as_number: :l__value_as_number }
+        { Sequel[:r][:value_as_number] => Sequel[:l][:value_as_number] }
       end
     end
   end

--- a/lib/conceptql/operators/except.rb
+++ b/lib/conceptql/operators/except.rb
@@ -11,8 +11,8 @@ module ConceptQL
       def query(db)
         if ignore_dates?
           query = db.from(Sequel.as(left.evaluate(db), :l))
-            .left_join(Sequel.as(right.evaluate(db), :r), l__criterion_id: :r__criterion_id, l__criterion_domain: :r__criterion_domain)
-            .where(r__criterion_id: nil)
+            .left_join(Sequel.as(right.evaluate(db), :r), criterion_id: :criterion_id, criterion_domain: :criterion_domain)
+            .where(Sequel[:r][:criterion_id] => nil)
             .select_all(:l)
           db.from(query)
         else

--- a/lib/conceptql/operators/filter.rb
+++ b/lib/conceptql/operators/filter.rb
@@ -13,8 +13,8 @@ module ConceptQL
         rhs = rhs.from_self.select_group(:person_id, :criterion_id, :criterion_domain)
         query = db.from(Sequel.as(left.evaluate(db), :l))
         query = query
-          .left_join(Sequel.as(rhs, :r), l__person_id: :r__person_id, l__criterion_id: :r__criterion_id, l__criterion_domain: :r__criterion_domain)
-          .exclude(r__criterion_id: nil)
+          .left_join(Sequel.as(rhs, :r), person_id: :person_id, criterion_id: :criterion_id, criterion_domain: :criterion_domain)
+          .exclude(Sequel[:r][:criterion_id] => nil)
           .select_all(:l)
         db.from(query)
       end

--- a/lib/conceptql/operators/occurrence.rb
+++ b/lib/conceptql/operators/occurrence.rb
@@ -100,7 +100,7 @@ occurrence, this operator returns nothing for that person.
           .from_self
         db[:uniqued]
           .with(:uniqued, uniquify)
-          .select_append { |o| o.row_number(:over, partition: uniquify_partition_columns, order: ordered_columns){}.as(:unique_rn) }
+          .select_append { |o| o.row_number.function.over(partition: uniquify_partition_columns, order: ordered_columns).as(:unique_rn) }
           .from_self
           .where(unique_rn: 1)
       end

--- a/lib/conceptql/operators/occurrence.rb
+++ b/lib/conceptql/operators/occurrence.rb
@@ -65,7 +65,7 @@ occurrence, this operator returns nothing for that person.
       def occurrences(db)
         all_or_uniquified_results(db)
           .from_self
-          .select_append { |o| o.row_number(:over, partition: :person_id, order: ordered_columns){}.as(:rn) }
+          .select_append { |o| o.row_number.function.over(partition: :person_id, order: ordered_columns).as(:rn) }
       end
 
       private

--- a/lib/conceptql/operators/operator.rb
+++ b/lib/conceptql/operators/operator.rb
@@ -347,7 +347,7 @@ module ConceptQL
       end
 
       def make_table_name(table)
-        "#{table}___tab".to_sym
+        Sequel.qualify(table, :tab)
       end
 
       def query_cols

--- a/lib/conceptql/operators/operator.rb
+++ b/lib/conceptql/operators/operator.rb
@@ -347,7 +347,7 @@ module ConceptQL
       end
 
       def make_table_name(table)
-        Sequel.qualify(table, :tab)
+        Sequel.as(table, :tab)
       end
 
       def query_cols

--- a/lib/conceptql/operators/overlapped_by.rb
+++ b/lib/conceptql/operators/overlapped_by.rb
@@ -16,9 +16,9 @@ L---N---L
       EOF
       def where_clause
         if inclusive?
-          [Proc.new { r__start_date <= l__start_date}, Proc.new { l__start_date <= r__end_date }]
+          Sequel.expr { (r[:start_date] <= l[:start_date]) & (l[:start_date] <= r[:end_date]) }
         else
-          [Proc.new { r__start_date <= l__start_date}, Proc.new { l__start_date <= r__end_date }, Proc.new { r__end_date <= l__end_date }]
+          Sequel.expr { (r[:start_date] <= l[:start_date]) & (l[:start_date] <= r[:end_date]) & (r[:end_date] <= l[:end_date]) }
         end
       end
     end

--- a/lib/conceptql/operators/overlaps.rb
+++ b/lib/conceptql/operators/overlaps.rb
@@ -14,7 +14,7 @@ L---Y---L
         L---N---L
       EOF
       def where_clause
-        [Proc.new { l__start_date <= r__start_date}, Proc.new { r__start_date <= l__end_date }, Proc.new { l__end_date <= r__end_date }]
+        Sequel.expr { (l[:start_date] <= r[:start_date]) & (r[:start_date] <= l[:end_date]) & (l[:end_date] <= r[:end_date]) }
       end
     end
   end

--- a/lib/conceptql/operators/place_of_service_code.rb
+++ b/lib/conceptql/operators/place_of_service_code.rb
@@ -52,18 +52,18 @@ module ConceptQL
           db.from(:clinical_codes)
             .where(context_id: contexts)
         else
-          db.from(:visit_occurrence___v)
-            .join(:concept___c, { c__concept_id: pos_concept_column  })
-            .where(c__concept_code: arguments.map(&:to_s))
-            .where(c__vocabulary_id: 14)
+          db.from(Sequel[:visit_occurrence].as(:v))
+            .join(Sequel[:concept].as(:c), concept_id: pos_concept_column)
+            .where(Sequel[:c][:concept_code] => arguments.map(&:to_s))
+            .where(Sequel[:c][:vocabulary_id] => 14)
         end
       end
 
       private
 
       def pos_concept_column
-        return Sequel.cast(:v__visit_source_concept_id, :bigint) unless omopv4?
-        Sequel.cast(:v__place_of_service_concept_id, :bigint)
+        return Sequel.cast(Sequel[:v][:visit_source_concept_id], :bigint) unless omopv4?
+        Sequel.cast(Sequel[:v][:place_of_service_concept_id], :bigint)
       end
     end
   end

--- a/lib/conceptql/operators/source_vocabulary_operator.rb
+++ b/lib/conceptql/operators/source_vocabulary_operator.rb
@@ -32,7 +32,7 @@ module ConceptQL
         return vocab_op.query(db) if gdm?
         ds = db.from(table_name).where(conditions(db))
         if omopv4?
-          ds = ds.join(:source_to_concept_map___scm, [[:scm__target_concept_id, table_concept_column], [:scm__source_code, table_source_column]])
+          ds = ds.join(Sequel[:source_to_concept_map].as(:scm), [[Sequel[:scm][:target_concept_id], table_concept_column], [Sequel[:scm][:source_code], table_source_column]])
         end
         ds
       end
@@ -57,7 +57,7 @@ module ConceptQL
 
       def conditions(db)
         if omopv4?
-          [[:scm__source_code, arguments_fix(db)], [:scm__source_vocabulary_id, vocabulary_id]]
+          [[Sequel[:scm][:source_code], arguments_fix(db)], [Sequel[:scm][:source_vocabulary_id], vocabulary_id]]
         else
           conditions = { code_column => arguments_fix(db) }
           conditions[vocabulary_id_column] = vocabulary_id if vocabulary_id_column
@@ -98,7 +98,7 @@ module ConceptQL
       end
 
       def table_source_column
-        "tab__#{source_column}".to_sym
+        Sequel.qualify(:tab, source_column)
       end
 
       def table_is_missing?(db)

--- a/lib/conceptql/operators/standard_vocabulary_operator.rb
+++ b/lib/conceptql/operators/standard_vocabulary_operator.rb
@@ -25,7 +25,7 @@ module ConceptQL
         ds = db.from(table_name)
           .where(conditions(db))
         if omopv4?
-          ds = ds.join(:concept___c, c__concept_id: table_concept_column)
+          ds = ds.join(Sequel[:concept].as(:c), concept_id: table_concept_column)
         end
         ds
       end
@@ -40,7 +40,7 @@ module ConceptQL
 
       def conditions(db)
         if omopv4?
-          {c__concept_code: arguments_fix(db), c__vocabulary_id: vocabulary_id}
+          {Sequel[:c][:concept_code] => arguments_fix(db), Sequel[:c][:vocabulary_id] => vocabulary_id}
         else
           conditions = { code_column => arguments_fix(db) }
           conditions[vocabulary_id_column] = vocabulary_id if vocabulary_id_column

--- a/lib/conceptql/operators/started_by.rb
+++ b/lib/conceptql/operators/started_by.rb
@@ -11,12 +11,7 @@ R-------R
 L--N--L
       EOF
       def where_clause
-        [ { l__start_date: :r__start_date } ] + \
-        if inclusive?
-          [ Proc.new { l__end_date >= r__end_date } ]
-        else
-          [ Proc.new { l__end_date > r__end_date } ]
-        end
+        Sequel.&({Sequel[:l][:start_date] => Sequel[:r][:start_date]}, Sequel[:l][:end_date].send(inclusive? ? :>= : :>, Sequel[:r][:end_date])) 
       end
     end
   end

--- a/lib/conceptql/operators/temporal_operator.rb
+++ b/lib/conceptql/operators/temporal_operator.rb
@@ -62,7 +62,7 @@ module ConceptQL
       def add_occurrences_condition(ds, occurrences)
         occurrences_col = occurrences_column
         ds.distinct.from_self
-          .select_append{row_number{}.over(:partition => :person_id, :order => occurrences_col).as(:occurrence)}
+          .select_append{row_number.function.over(:partition => :person_id, :order => occurrences_col).as(:occurrence)}
           .from_self
           .select(*dm.columns)
           .where{occurrence > occurrences.to_i}

--- a/lib/conceptql/operators/temporal_operator.rb
+++ b/lib/conceptql/operators/temporal_operator.rb
@@ -25,7 +25,7 @@ module ConceptQL
 
       def query(db)
         ds = db.from(left_stream(db))
-               .join(right_stream(db), l__person_id: :r__person_id)
+               .join(right_stream(db), person_id: :person_id)
                .where(where_clause)
                .select_all(:l)
 
@@ -51,8 +51,8 @@ module ConceptQL
 
       def add_within_condition(ds, within, meth=:where)
         within = DateAdjuster.new(self, within)
-        after = within.adjust(:r__start_date, true)
-        before = within.adjust(:r__end_date)
+        after = within.adjust(Sequel[:r][:start_date], true)
+        before = within.adjust(Sequel[:r][:end_date])
         within_col = Sequel.expr(within_column)
         ds = ds.send(meth){within_col >= after} if within_check_after?
         ds = ds.send(meth){within_col <= before} if within_check_before?
@@ -69,7 +69,7 @@ module ConceptQL
       end
 
       def within_column
-        :l__start_date
+        Sequel[:l][:start_date]
       end
 
       def occurrences_column

--- a/lib/conceptql/operators/trim_date_start.rb
+++ b/lib/conceptql/operators/trim_date_start.rb
@@ -34,17 +34,16 @@ is passed through unaffected.
       def query(db)
         grouped_right = db.from(right_stream(db)).select_group(:person_id).select_append(Sequel.as(Sequel.function(:max, :end_date), :end_date))
 
-        where_criteria = Sequel.expr { l__end_date >= r__end_date }
-        where_criteria = where_criteria.|(r__end_date: nil)
+        where_criteria = Sequel.expr { (l[:end_date] >= r[:end_date]) | {r[:end_date] => nil} }
 
         # If the RHS's min start date is less than the LHS start date,
         # the entire LHS date range is truncated, which implies the row itself
         # is ineligible to pass thru
         ds = db.from(left_stream(db))
-                  .left_join(Sequel.as(grouped_right, :r), l__person_id: :r__person_id)
+                  .left_join(Sequel.as(grouped_right, :r), person_id: :person_id)
                   .where(where_criteria)
                   .select(*new_columns)
-                  .select_append(Sequel.as(Sequel.function(:greatest, :l__start_date, :r__end_date), :start_date))
+                  .select_append(Sequel.as(Sequel.function(:greatest, Sequel[:l][:start_date], Sequel[:r][:end_date]), :start_date))
 
         ds = add_option_conditions(ds)
         ds.from_self
@@ -57,7 +56,7 @@ is passed through unaffected.
       end
 
       def new_columns
-        (dynamic_columns - [:start_date]).map { |col| "l__#{col}".to_sym }
+        (dynamic_columns - [:start_date]).map { |col| Sequel[:l][col] }
       end
     end
   end

--- a/lib/conceptql/operators/vocabulary_operator.rb
+++ b/lib/conceptql/operators/vocabulary_operator.rb
@@ -65,7 +65,7 @@ module ConceptQL
       end
 
       def table_concept_column
-        "tab__#{concept_column}".to_sym
+        Sequel.qualify(:tab, concept_column)
       end
 
       def vocab_op

--- a/lib/conceptql/query_modifiers/gdm/drug_query_modifier.rb
+++ b/lib/conceptql/query_modifiers/gdm/drug_query_modifier.rb
@@ -26,15 +26,15 @@ module ConceptQL
           return query unless dm.table_cols(source_table).tap { |o| p o }.include?(:drug_exposure_detail_id)
           #TODO: Determine what actual columns to include for drug exposures under
           query.from_self(alias: :cc)
-            .left_join(:drug_exposure_details___de, cc__drug_exposure_detail_id: :de__id)
-            .left_join(:concepts___dose_con, de__dose_unit_concept_id: :dose_con__id)
-            .left_join(:concepts___ing_con, cc__clinical_code_concept_id: :ing_con__id)
+            .left_join(Sequel[:drug_exposure_details].as(:de), Sequel[:cc][:drug_exposure_detail_id] => Sequel[:de][:id])
+            .left_join(Sequel[:concepts].as(:dose_con), Sequel[:de][:dose_unit_concept_id] => Sequel[:dose_con][:id])
+            .left_join(Sequel[:concepts].as(:ing_con), Sequel[:cc][:clinical_code_concept_id] => Sequel[:ing_con][:id])
             .select_all(:cc)
-            .select_append(:de__dose_value___drug_amount)
-            .select_append(:dose_con__concept_text___drug_amount_units)
-            .select_append(:ing_con__concept_text___drug_name)
-            .select_append(:de__days_supply___drug_days_supply)
-            .select_append(:de__refills___drug_quantity)
+            .select_append(Sequel[:de][:dose_value].as(:drug_amount))
+            .select_append(Sequel[:dose_con][:concept_text].as(:drug_amount_units))
+            .select_append(Sequel[:ing_con][:concept_text].as(:drug_name))
+            .select_append(Sequel[:de][:days_supply].as(:drug_days_supply))
+            .select_append(Sequel[:de][:refills].as(:drug_quantity))
             .from_self
         end
 

--- a/lib/conceptql/query_modifiers/gdm/provider_query_modifier.rb
+++ b/lib/conceptql/query_modifiers/gdm/provider_query_modifier.rb
@@ -17,14 +17,14 @@ module ConceptQL
         def modified_query
           p source_table
           if dm.table_cols(source_table).include?(:context_id)
-            query.from_self(alias: "c")
-              .join(:contexts_practitioners___cp, cp__context_id: :c__context_id)
+            query.from_self(alias: :c)
+              .join(Sequel[:contexts_practitioners].as(:cp), context_id: :context_id)
               .select_all(:c)
-              .select_append(:cp__practitioner_id___provider_id)
+              .select_append(Sequel[:cp][:practitioner_id].as(:provider_id))
           else
             query
               .select_all
-              .select_append(:practitioner_id___provider_id)
+              .select_append(Sequel[:practitioner_id].as(:provider_id))
           end.from_self
         end
 

--- a/lib/conceptql/query_modifiers/omopv4_plus/drug_query_modifier.rb
+++ b/lib/conceptql/query_modifiers/omopv4_plus/drug_query_modifier.rb
@@ -28,11 +28,11 @@ module ConceptQL
         def modified_query
           return query unless dm.table_cols(source_table).include?(:drug_concept_id)
           query.from_self(alias: :de)
-            .left_join(micro_table.as(:mt), mt__drug_concept_id: :de__drug_concept_id)
+            .left_join(micro_table.as(:mt), drug_concept_id: :drug_concept_id)
             .select_all(:de)
-            .select_append(:mt__amount_value___drug_amount)
-            .select_append(:mt__amount_unit___drug_amount_units)
-            .select_append(:mt__drug_name___drug_name)
+            .select_append(Sequel[:mt][:amount_value].as(:drug_amount))
+            .select_append(Sequel[:mt][:amount_unit].as(:drug_amount_units))
+            .select_append(Sequel[:mt][:drug_name].as(:drug_name))
             .from_self
         end
 
@@ -41,13 +41,13 @@ module ConceptQL
         def micro_table
           # TODO: Does drug_strength only have RXNORM concept_ids?
           # TODO: What is vocabulary for units?  Can we shrink concept table to just that vocab before joining?
-          db.from(:concept___dc)
-            .left_join(:drug_strength___ds, ds__drug_concept_id: :dc__concept_id)
+          db.from(Sequel[:concept].as(:dc))
+            .left_join(Sequel[:drug_strength].as(:ds), drug_concept_id: :concept_id)
             .select(
-              :ds__drug_concept_id___drug_concept_id,
-              :ds__amount_value___amount_value,
-              :ds__amount_unit___amount_unit,
-              :dc__concept_name___drug_name,
+              Sequel[:ds][:drug_concept_id].as(:drug_concept_id),
+              Sequel[:ds][:amount_value].as(:amount_value),
+              Sequel[:ds][:amount_unit].as(:amount_unit),
+              Sequel[:dc][:concept_name].as(:drug_name),
             )
         end
       end

--- a/lib/conceptql/query_modifiers/omopv4_plus/provider_query_modifier.rb
+++ b/lib/conceptql/query_modifiers/omopv4_plus/provider_query_modifier.rb
@@ -16,15 +16,15 @@ module ConceptQL
 
         def modified_query
           if dm.table_cols(source_table).include?(:context_id)
-            query.from_self(alias: "c")
-              .join(:contexts_practitioners___cp, cp__context_id: :c__context_id)
+            query.from_self(alias: :c)
+              .join(Sequel[:contexts_practitioners].as(:cp), context_id: :context_id)
               .select_all(:c)
-              .select_append(:cp__practitioner_id___provider_id)
+              .select_append(Sequel[:cp][:practitioner_id].as(:provider_id))
               .from_self
           else
             query
               .select_all
-              .select_append(:practitioner_id___provider_id)
+              .select_append(Sequel[:practitioner_id].as(:provider_id))
           end
         end
 

--- a/test/all_operations_test.rb
+++ b/test/all_operations_test.rb
@@ -1,8 +1,9 @@
 require_relative "./db_helper"
 
 file_regexps = nil
-if !ARGV.empty?
-  file_regexps = ARGV.map { |f| /#{f}/ }
+argv = ARGV.reject { |f| f.start_with?('-') }
+if !argv.empty?
+  file_regexps = argv.map { |f| /#{f}/ }
 end
 
 describe ConceptQL::Operators do

--- a/test/db_setup.rb
+++ b/test/db_setup.rb
@@ -54,7 +54,7 @@ end
 DB.create_table?(:organization, :ignore_index_errors=>true) do
   Bignum :organization_id, :primary_key=>true
   Bignum :place_of_service_concept_id
-  foreign_key :location_id, :location, :type=>Bignum
+  foreign_key :location_id, :location, :type=>:Bignum
   String :organization_source_value, :size=>50, :null=>false
   String :place_of_service_source_value, :size=>50
 end
@@ -67,8 +67,8 @@ DB.create_table?(:person, :ignore_index_errors=>true) do
   Integer :day_of_birth
   Bignum :race_concept_id
   Bignum :ethnicity_concept_id
-  foreign_key :location_id, :location, :type=>Bignum
-  foreign_key :provider_id, :provider, :type=>Bignum
+  foreign_key :location_id, :location, :type=>:Bignum
+  foreign_key :provider_id, :provider, :type=>:Bignum
   Bignum :care_site_id
   String :person_source_value, :size=>50
   String :gender_source_value, :size=>50
@@ -78,7 +78,7 @@ end
 
 DB.create_table?(:condition_era, :ignore_index_errors=>true) do
   Bignum :condition_era_id, :primary_key=>true
-  foreign_key :person_id, :person, :type=>Bignum, :null=>false
+  foreign_key :person_id, :person, :type=>:Bignum, :null=>false
   Bignum :condition_concept_id, :null=>false
   Date :condition_era_start_date, :null=>false
   Date :condition_era_end_date, :null=>false
@@ -88,7 +88,7 @@ end
 
 DB.create_table?(:condition_occurrence, :ignore_index_errors=>true) do
   Bignum :condition_occurrence_id, :primary_key=>true
-  foreign_key :person_id, :person, :type=>Bignum, :null=>false
+  foreign_key :person_id, :person, :type=>:Bignum, :null=>false
   Bignum :condition_concept_id, :null=>false
   Date :condition_start_date, :null=>false
   Date :condition_end_date
@@ -100,7 +100,7 @@ DB.create_table?(:condition_occurrence, :ignore_index_errors=>true) do
 end
 
 DB.create_table?(:death, :ignore_index_errors=>true) do
-  foreign_key :person_id, :person, :type=>Bignum, :primary_key=>true
+  foreign_key :person_id, :person, :type=>:Bignum, :primary_key=>true
   Date :death_date, :null=>false
   Bignum :death_type_concept_id, :null=>false
   Bignum :cause_of_death_concept_id
@@ -109,7 +109,7 @@ end
 
 DB.create_table?(:drug_era, :ignore_index_errors=>true) do
   Bignum :drug_era_id, :primary_key=>true
-  foreign_key :person_id, :person, :type=>Bignum, :null=>false
+  foreign_key :person_id, :person, :type=>:Bignum, :null=>false
   Bignum :drug_concept_id, :null=>false
   Date :drug_era_start_date, :null=>false
   Date :drug_era_end_date, :null=>false
@@ -119,7 +119,7 @@ end
 
 DB.create_table?(:drug_exposure, :ignore_index_errors=>true) do
   Bignum :drug_exposure_id, :primary_key=>true
-  foreign_key :person_id, :person, :type=>Bignum, :null=>false
+  foreign_key :person_id, :person, :type=>:Bignum, :null=>false
   Bignum :drug_concept_id, :null=>false
   Date :drug_exposure_start_date, :null=>false
   Date :drug_exposure_end_date
@@ -137,7 +137,7 @@ end
 
 DB.create_table?(:observation, :ignore_index_errors=>true) do
   Bignum :observation_id, :primary_key=>true
-  foreign_key :person_id, :person, :type=>Bignum, :null=>false
+  foreign_key :person_id, :person, :type=>:Bignum, :null=>false
   Bignum :observation_concept_id, :null=>false
   Date :observation_date, :null=>false
   Date :observation_time
@@ -157,7 +157,7 @@ end
 
 DB.create_table?(:observation_period, :ignore_index_errors=>true) do
   Bignum :observation_period_id, :primary_key=>true
-  foreign_key :person_id, :person, :type=>Bignum, :null=>false
+  foreign_key :person_id, :person, :type=>:Bignum, :null=>false
   Date :observation_period_start_date, :null=>false
   Date :observation_period_end_date, :null=>false
   Date :prev_ds_period_end_date
@@ -165,7 +165,7 @@ end
 
 DB.create_table?(:payer_plan_period, :ignore_index_errors=>true) do
   Bignum :payer_plan_period_id, :primary_key=>true
-  foreign_key :person_id, :person, :type=>Bignum, :null=>false
+  foreign_key :person_id, :person, :type=>:Bignum, :null=>false
   Date :payer_plan_period_start_date, :null=>false
   Date :payer_plan_period_end_date, :null=>false
   String :payer_source_value, :size=>50
@@ -176,7 +176,7 @@ end
 
 DB.create_table?(:procedure_occurrence, :ignore_index_errors=>true) do
   Bignum :procedure_occurrence_id, :primary_key=>true
-  foreign_key :person_id, :person, :type=>Bignum, :null=>false
+  foreign_key :person_id, :person, :type=>:Bignum, :null=>false
   Bignum :procedure_concept_id, :null=>false
   Date :procedure_date, :null=>false
   Bignum :procedure_type_concept_id, :null=>false
@@ -188,7 +188,7 @@ end
 
 DB.create_table?(:visit_occurrence, :ignore_index_errors=>true) do
   Bignum :visit_occurrence_id, :primary_key=>true
-  foreign_key :person_id, :person, :type=>Bignum, :null=>false
+  foreign_key :person_id, :person, :type=>:Bignum, :null=>false
   Date :visit_start_date, :null=>false
   Date :visit_end_date, :null=>false
   Bignum :place_of_service_concept_id, :null=>false
@@ -198,7 +198,7 @@ end
 
 DB.create_table?(:drug_cost, :ignore_index_errors=>true) do
   Bignum :drug_cost_id, :primary_key=>true
-  foreign_key :drug_exposure_id, :drug_exposure, :type=>Bignum, :null=>false
+  foreign_key :drug_exposure_id, :drug_exposure, :type=>:Bignum, :null=>false
   Float :paid_copay
   Float :paid_coinsurance
   Float :paid_toward_deductible
@@ -214,7 +214,7 @@ end
 
 DB.create_table?(:procedure_cost, :ignore_index_errors=>true) do
   Bignum :procedure_cost_id, :primary_key=>true
-  foreign_key :procedure_occurrence_id, :procedure_occurrence, :type=>Bignum, :null=>false
+  foreign_key :procedure_occurrence_id, :procedure_occurrence, :type=>:Bignum, :null=>false
   Float :paid_copay
   Float :paid_coinsurance
   Float :paid_toward_deductible


### PR DESCRIPTION
Symbol splitting will be disabled by default in Sequel 5, so all of
the double and triple underscores need to be removed and replaced
with Sequel objects.  In cases where joining is done, in general
there is no need for explicit qualification, but the implicit
qualification should be correct.

Sequel 5 will no longer allow multiple filter arguments and merge
them together, and will not longer allow Procs not passed as
blocks.  Just use Sequel.expr in the related code, which returns
a single expression.

Most of the tests fail for me both before and after this, possibly
because the data model was changed from omopv4 to omopv4_plus
and the PostgreSQL database I'm using is still using the omopv4 data
model.  If I can get a database copy using the omopv4_plus data model,
I can do some additional testing and potentially find more issues or fix
any bugs this pull request introduces.