### PR TITLE
Use unique CTE names

### DIFF
--- a/lib/conceptql.rb
+++ b/lib/conceptql.rb
@@ -16,8 +16,32 @@ require_relative "conceptql/query_modifiers/omopv4_plus/pos_query_modifier"
 require_relative "conceptql/query_modifiers/omopv4_plus/drug_query_modifier"
 require_relative "conceptql/query_modifiers/omopv4_plus/provenance_query_modifier"
 
+require 'securerandom'
 
 module ConceptQL
+  FORCE_TEMP_TABLES = !!ENV['CONCEPTQL_FORCE_TEMP_TABLES']
+  if FORCE_TEMP_TABLES
+    SCRATCH_DATABASE = ENV['DOCKER_SCRATCH_DATABASE']
+    unless SCRATCH_DATABASE && !SCRATCH_DATABASE.empty?
+      raise ArgumentError, "You must set the DOCKER_SCRATCH_DATABASE environment variable to the name of the scratch database if using the CONCEPTQL_FORCE_TEMP_TABLES environment variable"
+    end
+  else
+    SCRATCH_DATABASE = nil
+  end
+
+  i = 0
+  mutex = Mutex.new
+  CTE_NAME_NEXT = lambda{mutex.synchronize{i+=1}}
+  def self.cte_name(name)
+    name = Sequel.identifier("#{name}_#{$$}_#{CTE_NAME_NEXT.call}_#{SecureRandom.hex(16)}")
+
+    if SCRATCH_DATABASE
+      name = name.qualify(SCRATCH_DATABASE)
+    end
+
+    name
+  end
+
   def self.metadata(opts = {})
     {
       categories: categories,

--- a/lib/conceptql/operators/co_reported.rb
+++ b/lib/conceptql/operators/co_reported.rb
@@ -30,13 +30,14 @@ module ConceptQL
           q.intersect(tab)
         end
 
+        name = cte_name(:shared_context_ids)
         shared_events = contexteds.map do |contexted|
-          contexted.where(context_id: db[:shared_context_ids])
+          contexted.where(context_id: db[name])
         end
 
         shared_events.inject do |q, shared_event|
           q.union(shared_event)
-        end.with(:shared_context_ids, shared_context_ids)
+        end.with(name, shared_context_ids)
       end
 
       def contextify(db, stream)

--- a/lib/conceptql/operators/occurrence.rb
+++ b/lib/conceptql/operators/occurrence.rb
@@ -53,8 +53,9 @@ occurrence, this operator returns nothing for that person.
       end
 
       def query(db)
-        db[:occurrences]
-          .with(:occurrences, occurrences(db))
+        name = cte_name(:occurrences)
+        db[name]
+          .with(name, occurrences(db))
           .where(rn: occurrence.abs)
       end
 
@@ -98,8 +99,9 @@ occurrence, this operator returns nothing for that person.
         return stream.evaluate(db) unless options[:unique]
         uniquify = stream.evaluate(db)
           .from_self
-        db[:uniqued]
-          .with(:uniqued, uniquify)
+        name = cte_name(:uniqued)
+        db[name]
+          .with(name, uniquify)
           .select_append { |o| o.row_number.function.over(partition: uniquify_partition_columns, order: ordered_columns).as(:unique_rn) }
           .from_self
           .where(unique_rn: 1)

--- a/lib/conceptql/operators/operator.rb
+++ b/lib/conceptql/operators/operator.rb
@@ -135,6 +135,10 @@ module ConceptQL
         scope.query_columns
       end
 
+      def cte_name(name)
+        ConceptQL.cte_name(name)
+      end
+
       def annotate(db, opts = {})
         return @annotation if defined?(@annotation)
 

--- a/lib/conceptql/scope.rb
+++ b/lib/conceptql/scope.rb
@@ -50,6 +50,7 @@ module ConceptQL
       @known_operators = {}
       @recall_dependencies = {}
       @recall_stack = []
+      @label_cte_names = {}
       @annotation = {}
       @opts = opts.dup
       @annotation[:errors] = @errors = {}
@@ -129,7 +130,7 @@ module ConceptQL
     end
 
     def from(db, label)
-      ds = db.from(label)
+      ds = db.from(label_cte_name(label))
 
       if ENV['CONCEPTQL_CHECK_COLUMNS']
         # Work around requests for columns by operators.  These
@@ -186,10 +187,14 @@ module ConceptQL
       query = query.from_self
 
       ctes.each do |label, operator|
-        query = query.with(label, operator.evaluate(db))
+        query = query.with(label_cte_name(label), operator.evaluate(db))
       end
 
       query
+    end
+
+    def label_cte_name(label)
+      @label_cte_names[label] ||= ConceptQL.cte_name(label)
     end
 
     def ctes


### PR DESCRIPTION
This makes CTEs use unique names created with the process id, an
incrementing counter, and a random number.  This should make it
very unlikely there are collisions even when running simultaneously
on different hosts.

This also lays the groundwork for the CONCEPTQL_FORCE_TEMP_TABLES
and DOCKER_SCRATCH_DATABASE environment variables, but those won't
work correctly yet, I still need to add support so that
Dataset#each will strip off any ctes and create temp tables
for them, and clean up the temp tables after yielding all rows.