### PR TITLE
Make CONCEPTQL_CHECK_COLUMNS work on Sequel 5

### DIFF
--- a/lib/conceptql/scope.rb
+++ b/lib/conceptql/scope.rb
@@ -138,8 +138,10 @@ module ConceptQL
         # columns to still work, send the columns request to the
         # underlying operator.
         op = fetch_operator(label)
-        (class << ds; self; end).send(:define_method, :columns) do
-          (@main_op ||= op.evaluate(db)).columns
+        ds = ds.with_extend do
+          define_method(:columns) do
+            (@main_op ||= op.evaluate(db)).columns
+          end
         end
       end
 


### PR DESCRIPTION
In Sequel 5, datasets are frozen, so you can't modify the singleton
class of a dataset.  You can use with_extend instead, which returns
a modified copy. The with_extend block is passed is to Module.new,
and the resulting module extends the copy of the dataset.