### PR TITLE
Add Operator#semi_or_inner_join, and support in filter operator

### DIFF
--- a/lib/conceptql/operators/filter.rb
+++ b/lib/conceptql/operators/filter.rb
@@ -12,10 +12,7 @@ module ConceptQL
         rhs = right.evaluate(db)
         rhs = rhs.from_self.select_group(*columns)
         query = db.from(Sequel.as(left.evaluate(db), :l))
-        query = query
-          .left_join(Sequel.as(rhs, :r), join_columns)
-          .exclude(Sequel[:r][:criterion_id] => nil)
-          .select_all(:l)
+        query = semi_or_inner_join(query, rhs, join_columns)
         db.from(query)
       end
 
@@ -24,7 +21,7 @@ module ConceptQL
       end
 
       def join_columns
-        Hash[columns.zip(columns)]
+        columns.map{|c| [Sequel[:l][c], Sequel[:r][c]]}
       end
 
       def determine_columns

--- a/lib/conceptql/operators/operator.rb
+++ b/lib/conceptql/operators/operator.rb
@@ -29,6 +29,7 @@ module ConceptQL
       attr :nodifier, :values, :options, :arguments, :upstreams, :op_name
 
       option :label, type: :string
+      option :inner_join, type: :boolean
 
       @validations = []
 
@@ -607,6 +608,20 @@ module ConceptQL
 
       def preferred_name
         self.class.pref_name
+      end
+
+      def semi_or_inner_join(ds, table, expr)
+        table = Sequel[table] if table.is_a?(Symbol)
+        if options[:inner_join]
+          ds.join(table.as(:r), expr)
+            .select_all(:l)
+        else
+          ds.where(DB[table.as(:r)]
+            .select(1)
+            .where(expr)
+            .exists
+          )
+        end
       end
     end
   end


### PR DESCRIPTION
This is a work-in-progress pull request, not currently ready for merging.

I added support for the match operator locally, but it doesn't look like we have tests for that operator, so I haven't committed it.

I tried to add support for the place_of_service_code operator, but it doesn't appear to work there, maybe because it tried to select columns from the joined table (RHS) instead of the just the main table (LHS).

Please let me know what operators are the most important in terms of adding support for this, so I can work on those first.