### PR TITLE
Remove duplicate call to recursive_extract_cte_expr (Fixes #188)

### DIFF
--- a/lib/conceptql/scope.rb
+++ b/lib/conceptql/scope.rb
@@ -227,7 +227,6 @@ module ConceptQL
       #p [:rec, ctes, query.opts]
 
       if from = query.opts[:from]
-        from = from.map{|t| recursive_extract_cte_expr(t, ctes)}
         query = query.clone(:from=>from.map{|t| recursive_extract_cte_expr(t, ctes)})
         #p [:rec_from, ctes.map(&:first), from]
       end


### PR DESCRIPTION
Only one map should be done, not two maps.  Fixes infinite recursion
on the mock impala adapter.