### PR TITLE
Skip autoloading of minitest plugins

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -17,5 +17,6 @@ end
 
 $: << "lib"
 require 'conceptql'
+ENV['MT_NO_PLUGINS'] = '1' # Work around stupid autoloading of plugins
 require 'minitest/spec'
 require 'minitest/autorun'


### PR DESCRIPTION
Minitest looks in all installed gems to see if any have minitest
plugins, and then loads any plugins it finds, which is pretty
stupid behavior.  Thankfully, recent versions of minitest support
this escape hatch.