### PR TITLE
Add ability to log performance data during testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ rdoc
 spec/reports
 test/tmp
 test/version_tmp
+/test/performance
 tmp
 yamls/
 Gemfile.local


### PR DESCRIPTION
When the CONCEPTQL_PERFORMANCE_TEST_TIMES environment variable is
present and has a value greater than 0, after each successful
operator test, the test is run that many aditional times, and the
averaged elapsed time for the runs is appended to a CSV file in
the format:

sha1,adapter,database name,current time,average elapsed time

Where sha1 is the current git commit sha1 and the adapter is
a combination of the Sequel adapter_scheme and database_type.

This should address #107.