### PR TITLE
Fix concurrent_within operator on Impala

### DIFF
--- a/lib/conceptql/operators/concurrent_within.rb
+++ b/lib/conceptql/operators/concurrent_within.rb
@@ -37,7 +37,7 @@ module ConceptQL
               .where(adjusted_end_date >= Sequel[:r][:end_date])
               .select(*matching_columns)
 
-            matching = matching.where(matching_columns=>other)
+            matching = matching.where(other.where(matching_columns.map{|x| [Sequel.qualify(:l, x), Sequel.qualify(:r, x)]}).exists)
           end
 
           matching

--- a/lib/conceptql/window/table.rb
+++ b/lib/conceptql/window/table.rb
@@ -88,7 +88,7 @@ module ConceptQL
         # Though we may not be worthy of it, may we all be forgiven.
         if ENV["CONCEPTQL_IN_TEST_MODE"] ==  "I'm so sorry I did this"
 
-          final_columns = final_columns.map { |c| op.rdbms.partition_fix(c) }
+          final_columns = final_columns.map { |c| c == :person_id ? c : op.rdbms.partition_fix(c) }
         end
 
         final_columns += fixed_static_columns

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -23,7 +23,7 @@ require 'minitest/autorun'
 
 Minitest::Test.make_my_diffs_pretty!
 
-class Minitest::HooksSpec
+class Minitest::Spec
   if ENV['TESTS_DIV_MOD']
     div, mod = ENV['TESTS_DIV_MOD'].split(' ', 2).map(&:to_i)
     raise "invalid TESTS_DIV_MOD div: #{div}" unless div >= 2
@@ -31,11 +31,13 @@ class Minitest::HooksSpec
     test_number = -1
     inc = proc{test_number+=1}
 
-    define_singleton_method(:it) do |*a, &block|
-      if inc.call % div == mod
-        super(*a, &block)
+    singleton_class.prepend(Module.new do
+      define_method(:it) do |*a, &block|
+        if (i = inc.call) % div == mod
+          super(*a, &block)
+        end
       end
-    end
+    end)
   end
 
   def log
@@ -47,5 +49,3 @@ class Minitest::HooksSpec
     end
   end
 end
-
-


### PR DESCRIPTION
Impala can't handle (col1, col2) IN (subquery), and Sequel's
emulation cannot handle in this particular case.  Switch to
EXISTS (subquery WHERE l.col1 = r.col1 AND l.col2 = r.col2),
which can work in this particular case.

In a somewhat similar case, Sequel's select_remove extension
cannot handle cases where running the query to get the columns
doesn't work (and it doesn't in this case).  Do some manual
dataset introspection that works for many ConceptQL cases due
to the extensive use of SELECT * FROM (SELECT * FROM (SELECT * FROM,
and only fallback to the use of the select_remove if that
introspection doesn't work.