### PR TITLE
Move sequel_impala semi_join_first code into ConceptQL

### DIFF
--- a/lib/conceptql/operators/filter.rb
+++ b/lib/conceptql/operators/filter.rb
@@ -12,7 +12,7 @@ module ConceptQL
         rhs = right.evaluate(db)
         rhs = rhs.from_self.select_group(*columns)
         query = db.from(Sequel.as(left.evaluate(db), :l))
-        query = semi_or_inner_join(query, rhs, join_columns, rdbms.join_options)
+        query = semi_or_inner_join(query, rhs, join_columns)
         db.from(query)
       end
 

--- a/lib/conceptql/operators/operator.rb
+++ b/lib/conceptql/operators/operator.rb
@@ -627,7 +627,7 @@ module ConceptQL
         table = Sequel[table] if table.is_a?(Symbol)
         expr = exprs.inject(&:&)
         if use_inner_join?
-          ds.join(table.as(:r), expr, rdbms.join_options.merge(opts))
+          rdbms.inner_join(ds, table.as(:r), expr, opts)
             .select(*query_cols.map { |c| Sequel[:l][c] })
         else
           rdbms.semi_join(ds, table, *exprs)

--- a/lib/conceptql/rdbms/generic.rb
+++ b/lib/conceptql/rdbms/generic.rb
@@ -42,6 +42,10 @@ module ConceptQL
         new_column.as(column)
       end
 
+      def inner_join(ds, table, expr, opts={}, &block)
+        ds.join(table, expr, opts, &block)
+      end
+
       def semi_join(ds, table, *exprs)
         ds = Sequel[ds] if ds.is_a?(Symbol)
         table = Sequel[table] if table.is_a?(Symbol)

--- a/lib/conceptql/rdbms/generic.rb
+++ b/lib/conceptql/rdbms/generic.rb
@@ -11,7 +11,7 @@ module ConceptQL
         nodifier.scope
       end
 
-      def create_options
+      def create_options(_ds)
         {}
       end
 

--- a/lib/conceptql/rdbms/impala.rb
+++ b/lib/conceptql/rdbms/impala.rb
@@ -69,9 +69,9 @@ module ConceptQL
         items << Sequel.function(:split_part, Sequel.cast_string(:start_date), " ", 1)
       end
 
-      def create_options
+      def create_options(ds)
         opts = { parquet: true }
-        opts = opts.merge(sort_by: SORT_BY_COLUMNS & scope.query_columns) if ENV["CONCEPTQL_SORT_TEMP_TABLES"] == "true"
+        opts = opts.merge(sort_by: SORT_BY_COLUMNS & ds.columns) if ENV["CONCEPTQL_SORT_TEMP_TABLES"] == "true"
         opts
       end
 

--- a/lib/conceptql/rdbms/impala.rb
+++ b/lib/conceptql/rdbms/impala.rb
@@ -38,6 +38,8 @@ module ConceptQL
           ds = case CONCEPTQL_SEMI_JOIN_FIRST
           when :table
             temp_table = scope.cte_name("semi_join_table")
+            temp_table = temp_table.column if temp_table.is_a?(Sequel::SQL::QualifiedIdentifier)
+            temp_table = Sequel.identifier(temp_table) if temp_table.is_a?(String)
             ds.db.from(Sequel.as(temp_table, alias_name)).with(temp_table, ds)
           when true
             ds.from_self(:alias=>alias_name)

--- a/lib/conceptql/scope.rb
+++ b/lib/conceptql/scope.rb
@@ -278,7 +278,7 @@ module ConceptQL
                 begin
                   temp_tables.each do |table_name, ds|
                     #p [:create_table, table_name]
-                    db.create_table(table_name, rdbms.create_options.merge(as: ds))
+                    db.create_table(table_name, rdbms.create_options(ds).merge(as: ds))
                     rdbms.post_create(db, table_name)
                   end
 

--- a/test/db_helper.rb
+++ b/test/db_helper.rb
@@ -1,5 +1,5 @@
-require_relative "helper"
 require_relative "db"
+require_relative "helper"
 
 require "logger"
 require "pp"


### PR DESCRIPTION
This way it integrates with ConceptQL's query handling so that
ConceptQL is aware of all SQL being executed.  This keeps the
ability to use either subqueries or CTEs for the LEFT SEMI JOIN
expression, with temp tables for the CTEs if ConceptQL is
configured that way.

To implement this, I just moved more code into the rdbms object,
since rdbms.join_options will not handle it any more.

With CONCEPTQL_SEMI_JOIN_FIRST=table there is a failure in at
lease icd9/results_uuid3, which is a union of two identical
icd9 operators with the uuid option.  It duplicates the results
in that case, with all fields being identical except for the
uuid field, so I'm guessing something (maybe the uuid option
logic) needs to updated to support this.  No added failures with
CONCEPTQL_SEMI_JOIN_FIRST=true (which uses subqueries) in the
operators I tested.