### PR TITLE
Add tests for the From operator

### DIFF
--- a/lib/conceptql/operators/from.rb
+++ b/lib/conceptql/operators/from.rb
@@ -29,9 +29,17 @@ module ConceptQL
       end
 
       def table_name
+        return @table_name if @table_name
         name = values.first
-        name = name.to_sym if name.respond_to?(:to_sym)
-        name
+        if name.is_a?(String)
+          table, column = name.split('__', 2)
+          if column
+            name = Sequel.qualify(table, column)
+          else
+            name = name.to_sym
+          end
+        end
+        @table_name = name
       end
 
       def required_columns

--- a/lib/conceptql/operators/person.rb
+++ b/lib/conceptql/operators/person.rb
@@ -3,8 +3,6 @@ require_relative 'casting_operator'
 module ConceptQL
   module Operators
     class Person < CastingOperator
-      include ConceptQL::Behaviors::Windowable
-
       register __FILE__
 
       desc 'Generates all person records, or, if fed a stream, fetches all person records for the people represented in the incoming result set.'

--- a/lib/conceptql/operators/person.rb
+++ b/lib/conceptql/operators/person.rb
@@ -3,6 +3,8 @@ require_relative 'casting_operator'
 module ConceptQL
   module Operators
     class Person < CastingOperator
+      include ConceptQL::Behaviors::Windowable
+
       register __FILE__
 
       desc 'Generates all person records, or, if fed a stream, fetches all person records for the people represented in the incoming result set.'

--- a/test/from_operator_test.rb
+++ b/test/from_operator_test.rb
@@ -1,0 +1,18 @@
+require_relative 'db_helper'
+
+if scratch = ENV['DOCKER_SCRATCH_DATABASE']
+  describe ConceptQL::Operators::From do
+    temp_table = Sequel.qualify(scratch, :from_operator_test)
+
+    after do
+      DB.drop_table(temp_table)
+    end
+
+    it "should select from the table" do
+      DB.create_table(temp_table, :as=>CDB.query([:window, [:person], {person_ids: [1]}]).query)
+      CDB.query([:from, "#{scratch}__from_operator_test"]).query.all.must_equal DB[temp_table].all
+      CDB.query([:window, [:from, "#{scratch}__from_operator_test"], {person_ids: [1]}]).query.count.must_equal 1
+      CDB.query([:window, [:from, "#{scratch}__from_operator_test"], {person_ids: [2]}]).query.count.must_equal 0
+    end
+  end
+end

--- a/test/from_operator_test.rb
+++ b/test/from_operator_test.rb
@@ -9,10 +9,10 @@ if scratch = ENV['DOCKER_SCRATCH_DATABASE']
     end
 
     it "should select from the table" do
-      DB.create_table(temp_table, :as=>CDB.query([:window, [:person], {person_ids: [1]}]).query)
+      DB.create_table(temp_table, :as=>CDB.query([:window, [:person, [:icd9, '412']], {person_ids: [11]}]).query)
       CDB.query([:from, "#{scratch}__from_operator_test"]).query.all.must_equal DB[temp_table].all
-      CDB.query([:window, [:from, "#{scratch}__from_operator_test"], {person_ids: [1]}]).query.count.must_equal 1
-      CDB.query([:window, [:from, "#{scratch}__from_operator_test"], {person_ids: [2]}]).query.count.must_equal 0
+      CDB.query([:window, [:from, "#{scratch}__from_operator_test"], {person_ids: [11]}]).query.count.must_equal 1
+      CDB.query([:window, [:from, "#{scratch}__from_operator_test"], {person_ids: [12]}]).query.count.must_equal 0
     end
   end
 end


### PR DESCRIPTION
The From operator needs to be tested separately because it cannot
operate on the standard tables in either the gdm or omopv4_plus
data models.  To test it, a temp table has to be created first.

During the testing process, I noticed that the Person operator
was not windowable, which seems like a bug as it breaks ConceptQL
statements such as:

```
[:window, [:person], {person_ids: [1]}]
```

Also, to allow the From operator to be able to use qualified tables
passed in via JSON, I reinstituted __ splitting of strings for the
table.  This is necessary at least for the tests to make sure the
From operator can access tables that were created in a separate,
temporary Impala database/PostgreSQL schema.