### PR TITLE
Create tables for CTEs in labels before creating table for label

### DIFF
--- a/lib/conceptql/scope.rb
+++ b/lib/conceptql/scope.rb
@@ -259,8 +259,9 @@ module ConceptQL
       rdbms = op.rdbms
 
       query = query.from_self
-      temp_tables = ctes.map do |label, operator|
-        [label_cte_name(label), operator.evaluate(db)]
+      temp_tables = []
+      ctes.each do |label, operator|
+        temp_tables << [label_cte_name(label), recursive_extract_ctes(operator.evaluate(db), temp_tables)]
       end
 
       if force_temp_tables?


### PR DESCRIPTION
When figuring out the temp tables to create, if the temp tables
come from labels, go through each label temp table and extract
any CTEs and create tables for those CTEs first.

This fixes the occurrence and co_reported tests.