### PR TITLE
Extract CTEs in WHERE clauses

### DIFF
--- a/lib/conceptql/scope.rb
+++ b/lib/conceptql/scope.rb
@@ -1,6 +1,6 @@
 require_relative "window"
 require "securerandom"
-
+require "sequel"
 
 module ConceptQL
   # Scope coordinates the creation of any common table expressions that might


### PR DESCRIPTION
This uses Sequel::ASTTransformer to process the WHERE clause and
extract any CTEs from datasets in the WHERE clause.