### PR TITLE
Fix breakage caused CONCEPTQL_SORT_TEMP_TABLES=true

### DIFF
--- a/lib/conceptql/rdbms/impala.rb
+++ b/lib/conceptql/rdbms/impala.rb
@@ -46,9 +46,16 @@ module ConceptQL
         Sequel.function(:datediff, cast_date(to_column), cast_date(from_column))
       end
 
-      def create_options(scope)
+      def create_options(scope, ds)
         opts = { parquet: true }
-        opts = opts.merge(sort_by: SORT_BY_COLUMNS & scope.query_columns) if ENV["CONCEPTQL_SORT_TEMP_TABLES"] == "true"
+        if ENV["CONCEPTQL_SORT_TEMP_TABLES"] == "true"
+          sort_by_columns = if ds.opts[:values]
+            ds.opts[:values].first.map(&:alias)
+          else
+            SORT_BY_COLUMNS & scope.query_columns
+          end
+          opts[:sort_by] = sort_by_columns
+        end
         opts
       end
 

--- a/lib/conceptql/rdbms/postgres.rb
+++ b/lib/conceptql/rdbms/postgres.rb
@@ -7,7 +7,7 @@ module ConceptQL
         cast_date(to_column) - cast_date(from_column)
       end
 
-      def create_options(scope)
+      def create_options(scope, ds)
         {}
       end
 

--- a/lib/conceptql/scope.rb
+++ b/lib/conceptql/scope.rb
@@ -286,6 +286,7 @@ module ConceptQL
       end
 
       if force_temp_tables?
+        scope = self
         query = recursive_extract_ctes(query, temp_tables).with_extend do
           # Create temp tables for each CTE
           #
@@ -299,8 +300,7 @@ module ConceptQL
               if !temp_tables.empty? && !opts[:conceptql_temp_tables_created]
                 begin
                   temp_tables.each do |table_name, ds|
-                    #p [:create_table, table_name]
-                    db.create_table(table_name, rdbms.create_options(self).merge(as: ds))
+                    db.create_table(table_name, rdbms.create_options(scope, ds).merge(as: ds))
                     rdbms.post_create(db, table_name)
                   end
 

--- a/lib/conceptql/scope.rb
+++ b/lib/conceptql/scope.rb
@@ -299,7 +299,7 @@ module ConceptQL
             define_method(meth) do |*args, &block|
               if !temp_tables.empty? && !opts[:conceptql_temp_tables_created]
                 begin
-                  temp_tables.each do |table_name, ds|
+                  temp_tables.uniq(&:first).each do |table_name, ds|
                     db.create_table(table_name, rdbms.create_options(scope, ds).merge(as: ds))
                     rdbms.post_create(db, table_name)
                   end


### PR DESCRIPTION
b67e839e1ee1ca5aa039f93c9d0622f28f35a434 added the use of :sort_by
option if the CONCEPTQL_SORT_TEMP_TABLES env variable was set.  It
had create_options take a scope argument, but it did not pass the
ConceptQL::Scope object in, it passed a Sequel::Dataset instance in,
and the dataset it passed in was the dataset that was retrieving the
results, not the dataset that was used to build the temporary table.
This is because create_options(self) was used in a define_method
block inside one of the scope methods.  Fix this to actually pass
the scope in, by storing the scope in a local variable.

That change exposed another bug, which is that checking against the
scope's query_columns is not correct in all cases.  At least for the
failing query in question, which uses a VALUES query, we should use
the aliases in the first row of VALUES. To handle this, make
create_options take both the scope and the dataset that will be
used to create the temporary table, and explicitly check for the
:values option.  This code may need to be expanded in the future to
handle more query types.

Also, avoid trying to add the arg table twice as a temporary table,
as doing so would fail the second time.