### PR TITLE
Allow use of :no_temp_table Dataset#with option for not extracting CTE to temp table

### DIFF
--- a/lib/conceptql/operators/operator.rb
+++ b/lib/conceptql/operators/operator.rb
@@ -592,8 +592,13 @@ module ConceptQL
         args = args.map { |v| [v] }
         args_cte = db.values(args)
         args_cte_name = cte_name(:args)
+
+        if args_cte_name.is_a?(Sequel::SQL::QualifiedIdentifier)
+          args_cte_name = Sequel.identifier(args_cte_name.column)
+        end
+
         db[args_cte_name]
-          .with(args_cte_name, args_cte)
+          .with(args_cte_name, args_cte, :no_temp_table=>true)
           .select(:arg)
       end
 

--- a/lib/conceptql/scope.rb
+++ b/lib/conceptql/scope.rb
@@ -265,9 +265,10 @@ module ConceptQL
       end
 
       if with = query.opts[:with]
-        ctes.concat(with.map{|w| [w[:name], recursive_extract_ctes(w[:dataset], ctes)]})
+        keep, remove = with.partition{|w| w[:no_temp_table]}
+        ctes.concat(remove.map{|w| [w[:name], recursive_extract_ctes(w[:dataset], ctes)]})
         #p [:rec_with, ctes.map(&:first), with]
-        query = query.clone(:with=>nil)
+        query = query.clone(:with=>keep.empty? ? nil : keep)
       end
 
       query

--- a/test/lib/conceptql/operators/icd9_test.rb
+++ b/test/lib/conceptql/operators/icd9_test.rb
@@ -10,10 +10,11 @@ describe ConceptQL::Operators::Icd9 do
     ]
 
     sql = db.query(stmt).sql(:create_tables)
-    match_data = sql.scan(/(args_[^`]+)/).flatten
+    match_data = sql.scan(/FROM `(args_[^`]+)/).flatten
     match_data[0].must_match(/args_\d+/)
     match_data[1].must_match(/args_\d+/)
     match_data[0].wont_equal(match_data[1])
+    match_data.length.must_equal 2
   end
 end
 


### PR DESCRIPTION
Also, setup the args CTE on impala to not use a temp table.