### PR TITLE
Support CONCEPTQL_AVOID_CTES=true to avoid creating CTEs where possible

### DIFF
--- a/lib/conceptql.rb
+++ b/lib/conceptql.rb
@@ -16,6 +16,10 @@ Dir.glob(File.dirname(__FILE__) + "/../lib/conceptql/query_modifiers/**/*.rb").e
 end
 
 module ConceptQL
+  def self.avoid_ctes?
+    ENV['CONCEPTQL_AVOID_CTES'] == 'true'
+  end
+
   def self.metadata(opts = {})
     {
       categories: categories,

--- a/lib/conceptql/operators/operator.rb
+++ b/lib/conceptql/operators/operator.rb
@@ -597,6 +597,7 @@ module ConceptQL
           args_cte_name = Sequel.identifier(args_cte_name.column)
         end
 
+        # CTE here only used on impala due to needs_arguments_cte? above
         db[args_cte_name]
           .with(args_cte_name, args_cte, :no_temp_table=>true)
           .select(:arg)

--- a/lib/conceptql/scope.rb
+++ b/lib/conceptql/scope.rb
@@ -156,18 +156,22 @@ module ConceptQL
     end
 
     def from(db, label)
-      ds = db.from(label_cte_name(label))
+      if ConceptQL.avoid_ctes?
+        ds = db.from(fetch_operator(label).evaluate(db).as(label_cte_name(label)))
+      else
+        ds = db.from(label_cte_name(label))
 
-      if ENV['CONCEPTQL_CHECK_COLUMNS']
-        # Work around requests for columns by operators.  These
-        # would fail because the CTE would not be defined.  You
-        # don't want to define the CTE normally, but to allow the
-        # columns to still work, send the columns request to the
-        # underlying operator.
-        op = fetch_operator(label)
-        ds = ds.with_extend do
-          define_method(:columns) do
-            (@main_op ||= op.evaluate(db)).columns
+        if ENV['CONCEPTQL_CHECK_COLUMNS']
+          # Work around requests for columns by operators.  These
+          # would fail because the CTE would not be defined.  You
+          # don't want to define the CTE normally, but to allow the
+          # columns to still work, send the columns request to the
+          # underlying operator.
+          op = fetch_operator(label)
+          ds = ds.with_extend do
+            define_method(:columns) do
+              (@main_op ||= op.evaluate(db)).columns
+            end
           end
         end
       end
@@ -333,8 +337,10 @@ module ConceptQL
           end
         end
       else
-        temp_tables.each do |table_name, ds|
-          query = query.with(table_name, ds)
+        unless ConceptQL.avoid_ctes?
+          temp_tables.each do |table_name, ds|
+            query = query.with(table_name, ds)
+          end
         end
 
         query = query.with_extend do


### PR DESCRIPTION
CTEs are used in 4 places on PostgreSQL (1 additional place on Impala,
which I didn't modify):

* co_reported operator
* occurance operator (2 places)
* scope (for implementing recall operator)

Unfortunately, this approach does not help performance in the tests
when enabled:

co_reported: 15.2 seconds -> 16.6 seconds
occurrence: 50 seconds -> 152 seconds
recall: 1.4 seconds -> 2.5 seconds