### PR TITLE
Support CONCEPTQL_NO_CONSTANT_ORDER_BY environment variable on PostgreSQL/Redshift

### DIFF
--- a/lib/conceptql/rdbms/postgres.rb
+++ b/lib/conceptql/rdbms/postgres.rb
@@ -3,6 +3,16 @@ require_relative "generic"
 module ConceptQL
   module Rdbms
     class Postgres < Generic
+      def partition_fix(column, qualifier=nil)
+        # Hack used because this code doesn't know if we are using PostgreSQL or Redshift
+        return column unless ENV["CONCEPTQL_NO_CONSTANT_ORDER_BY"] == "true"
+
+        person_id = qualifier ? Sequel.qualify(qualifier, :person_id).cast_string : :person_id
+        person_id = Sequel.cast_string(person_id)
+        column = Sequel.expr(column).cast_string
+        column + '_' + person_id
+      end
+
       def days_between(from_column, to_column)
         cast_date(to_column) - cast_date(from_column)
       end


### PR DESCRIPTION
Since the redshift support currently reports the database type as
:postgres and not :redshift, and the Rdbms code doesn't have access
to the database in use to determine the actual type, allow this
environment variable to be set to force non-constant expressions in
order by.