### PR TITLE
Bump thor and activesupport gems for Rails 6.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in conceptql.gemspec
 gemspec
 gem "pg"
+gem "sequelizer", github: "mattschultz/sequelizer", branch: "eyeleteer-rails6"
 
 group :test, :development do
   gem "pry"

--- a/conceptql.gemspec
+++ b/conceptql.gemspec
@@ -18,10 +18,9 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'sequelizer', '~> 0.1'
-  spec.add_dependency 'thor', '~> 0.19'
+  spec.add_dependency 'thor', '~> 1.1'
   spec.add_dependency 'sequel', '~> 5.34'
-  spec.add_dependency 'activesupport', '~> 5'
+  spec.add_dependency 'activesupport', '>= 5.0', '< 7.0'
   spec.add_dependency 'bigdecimal'
   spec.add_dependency 'json'
   spec.add_development_dependency 'bundler', '~> 2.0'


### PR DESCRIPTION
The sequelizer dependency is temporarily pointing at https://github.com/mattschultz/sequelizer/tree/eyeleteer-rails6 until it can be merged into the upstream.